### PR TITLE
feat(generator): static headers, collection query params, and [FormBody]

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,0 +1,63 @@
+# Backlog
+
+Enhancements identified from real-world usage patterns. Items are independent and can be implemented in any order.
+
+---
+
+## 1. Static `[Header]` on methods
+
+**Status:** Attribute + `Value` property already exist — generator support is missing.
+
+The `HeaderAttribute` has a `Value` property intended for compile-time static headers on methods:
+
+```csharp
+[Get("/files/{path}")]
+[Header("Accept", Value = "application/octet-stream")]
+Task<byte[]> GetFileAsync(string path, CancellationToken ct = default);
+```
+
+Today, `Value` is never extracted by `ModelExtractor` and never emitted by `ClientEmitter`. The workaround is setting the header via `ConfigureHttpClient`, which is global — not per-method.
+
+**Work needed:**
+- Extract static headers from method-level `[Header]` attributes in `ModelExtractor.ExtractMethod`
+- Add a `StaticHeaders` collection to `MethodModel`
+- Emit `request.Headers.TryAddWithoutValidation(name, value)` in `ClientEmitter.EmitRequestCreation`
+
+---
+
+## 2. Multi-value query parameters (`IEnumerable<T>` with `[Query]`)
+
+**Status:** Not supported — passing a collection for a `[Query]` parameter emits a single value via `.ToString()`.
+
+APIs that accept repeated keys (`?tags=a&tags=b`) require manual query string construction today:
+
+```csharp
+[Get("/items")]
+Task<List<ItemDto>> SearchAsync([Query] IEnumerable<string> tags, CancellationToken ct = default);
+// desired: ?tags=a&tags=b
+```
+
+**Work needed:**
+- Detect `IEnumerable<T>` (excluding `string`) on `[Query]` parameters in `ModelExtractor`
+- Add an `IsCollection` flag to `ParameterModel`
+- In `ClientEmitter`, emit a `foreach` loop over the collection, appending each value as a separate `key=value` pair
+- Handle nullable collections
+
+---
+
+## 3. Form-encoded body (`[FormBody]`)
+
+**Status:** Not supported — the generator only serializes bodies via `IRestSerializer` (JSON, MessagePack, etc.).
+
+OAuth token endpoints and many legacy APIs require `application/x-www-form-urlencoded`. Today there is no way to declare this on the interface:
+
+```csharp
+[Post("/oauth/token")]
+Task<TokenResponse> GetTokenAsync([FormBody] TokenRequest request, CancellationToken ct = default);
+```
+
+**Work needed:**
+- Add `FormBodyAttribute` to `ZeroAlloc.Rest.Attributes`
+- Detect it in `ModelExtractor` (new `ParameterKind.FormBody`)
+- In `ClientEmitter`, emit `FormUrlEncodedContent` built from the parameter's public properties (source-generated via a helper, to stay AOT-safe — no reflection)
+- Consider a `Dictionary<string, string>` overload as a simpler escape hatch

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -75,3 +75,51 @@ Every method should end with `CancellationToken ct = default`. The generator rec
 | `[Body]` | Request body | Serialized by `IRestSerializer` |
 | `[Header("Name")]` | Request header | Exact header name required |
 | `CancellationToken` | (automatic) | Recognised by type, no attribute needed |
+| `[Header("Name", Value = "...")]` on method | Static request header | Compile-time constant; silently ignored when `Value` is omitted |
+| `[Query]` on `IEnumerable<T>` | Repeated query keys | Null items skipped; null collection emits nothing |
+| `[FormBody]` | Form-encoded body | `IEnumerable<KeyValuePair<string,string>>`; no serializer used |
+
+### Static headers on methods
+
+Use `[Header("Name", Value = "literal")]` on a method to emit a compile-time header. The header is added to every request for that method, independent of the serializer.
+
+```csharp
+[Get("/files/{id}")]
+[Header("Accept", Value = "application/octet-stream")]
+Task<byte[]> GetFileAsync(int id, CancellationToken ct = default);
+```
+
+> **Note:** Static headers are *additive*. If you set `Accept` via `[Header]` and the serializer also sets `Accept`, both values appear in the outgoing header. Use `ConfigureHttpClient` if you need exclusive control over `Accept`.
+
+If `Value` is omitted on a method-level `[Header]`, the attribute is silently ignored.
+
+### Multi-value query parameters
+
+Annotate an `IEnumerable<T>` parameter with `[Query]` to emit repeated query string keys (`?tags=a&tags=b`).
+
+```csharp
+[Get("/items")]
+Task<List<ItemDto>> SearchAsync([Query] IEnumerable<string>? tags, CancellationToken ct = default);
+// ?tags=admin&tags=active
+```
+
+Null items inside the collection are skipped. A `null` collection emits no query keys. The parameter type must implement `IEnumerable<T>` (e.g. `List<T>`, `string[]`, `IReadOnlyList<T>`). Passing `string` is treated as a scalar (strings are `IEnumerable<char>` but that case is excluded).
+
+### Form-encoded body
+
+Use `[FormBody]` to send `application/x-www-form-urlencoded` content without a serializer. The parameter type must be `IEnumerable<KeyValuePair<string, string>>` (e.g. `Dictionary<string, string>`).
+
+```csharp
+[Post("/oauth/token")]
+Task<TokenResponse> GetTokenAsync([FormBody] Dictionary<string, string> form, CancellationToken ct = default);
+```
+
+```csharp
+var token = await api.GetTokenAsync(new Dictionary<string, string>
+{
+    ["grant_type"] = "client_credentials",
+    ["client_id"] = "my-app"
+});
+```
+
+`[FormBody]` and `[Body]` are mutually exclusive on the same method. Using both produces a `ZRA001` compile-time error.

--- a/docs/plans/2026-04-12-backlog-enhancements.md
+++ b/docs/plans/2026-04-12-backlog-enhancements.md
@@ -1,0 +1,566 @@
+# Backlog Enhancements Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Implement three generator enhancements: static method-level `[Header]`, multi-value `[Query]` collections, and form-encoded `[FormBody]`.
+
+**Architecture:** Each enhancement follows the same three-layer pattern — attribute definition in `ZeroAlloc.Rest`, model extraction in `ModelExtractor`, code emission in `ClientEmitter`. All changes are tested at two levels: generator emission tests (assert on generated source text) and integration tests (assert on real HTTP behaviour via WireMock).
+
+**Tech Stack:** C# 10 / .NET 10, Roslyn source generators (netstandard2.0 target), xUnit, WireMock.Net
+
+---
+
+## Task 1: Static `[Header]` on methods
+
+The `HeaderAttribute` already has a `Value` property but the generator never reads it when the attribute is placed on a *method* (only on parameters). This task wires it up.
+
+**Files:**
+- Modify: `src/ZeroAlloc.Rest.Generator/Models/MethodModel.cs`
+- Modify: `src/ZeroAlloc.Rest.Generator/ModelExtractor.cs`
+- Modify: `src/ZeroAlloc.Rest.Generator/ClientEmitter.cs`
+- Modify: `tests/ZeroAlloc.Rest.Generator.Tests/GeneratorEmissionTests.cs`
+- Modify: `tests/ZeroAlloc.Rest.Integration.Tests/TestInterfaces/IUserApi.cs`
+- Modify: `tests/ZeroAlloc.Rest.Integration.Tests/UserApiTests.cs`
+
+---
+
+### Step 1: Write the failing emission test
+
+Add to `GeneratorEmissionTests.cs`:
+
+```csharp
+[Fact]
+public void StaticHeader_OnMethod_EmittedInGeneratedCode()
+{
+    var source = """
+        using ZeroAlloc.Rest.Attributes;
+        namespace MyApp;
+        [ZeroAllocRestClient]
+        public interface IFileApi
+        {
+            [Get("/files/{id}")]
+            [Header("Accept", Value = "application/octet-stream")]
+            System.Threading.Tasks.Task<string> GetFileAsync(int id, System.Threading.CancellationToken ct = default);
+        }
+        """;
+    var output = GetGeneratedSource(source, "IFileApi.g.cs");
+    Assert.Contains("\"Accept\"", output);
+    Assert.Contains("\"application/octet-stream\"", output);
+    Assert.Contains("TryAddWithoutValidation", output);
+}
+```
+
+### Step 2: Run test to verify it fails
+
+```
+dotnet test tests/ZeroAlloc.Rest.Generator.Tests/ -q --filter "StaticHeader_OnMethod_EmittedInGeneratedCode"
+```
+Expected: FAIL — the generated source won't contain the static header.
+
+### Step 3: Add `StaticHeaders` to `MethodModel`
+
+Replace the record in `src/ZeroAlloc.Rest.Generator/Models/MethodModel.cs`:
+
+```csharp
+using System.Collections.Generic;
+
+namespace ZeroAlloc.Rest.Generator.Models;
+
+internal record MethodModel(
+    string Name,
+    string HttpMethod,
+    string Route,
+    string ReturnTypeName,
+    string? InnerTypeName,
+    bool ReturnsResult,
+    bool ReturnsVoid,
+    IReadOnlyList<ParameterModel> Parameters,
+    string? SerializerTypeName,
+    IReadOnlyList<(string Name, string Value)> StaticHeaders);
+```
+
+### Step 4: Extract static headers in `ModelExtractor.ExtractMethod`
+
+In `ModelExtractor.cs`, after the existing `httpMethod`/`route` extraction loop, add (before the early return):
+
+```csharp
+var staticHeaders = new List<(string, string)>();
+foreach (var attr in method.GetAttributes())
+{
+    if (attr.AttributeClass?.ToDisplayString() != HeaderAttr) continue;
+    if (attr.ConstructorArguments.Length == 0) continue;
+    var headerName = attr.ConstructorArguments[0].Value as string;
+    if (headerName is null) continue;
+    string? headerValue = null;
+    foreach (var namedArg in attr.NamedArguments)
+    {
+        if (namedArg.Key == "Value" && namedArg.Value.Value is string v)
+        {
+            headerValue = v;
+            break;
+        }
+    }
+    if (headerValue != null)
+        staticHeaders.Add((headerName, headerValue));
+}
+```
+
+Then update the `return new MethodModel(...)` call to pass `staticHeaders.AsReadOnly()` as the last argument.
+
+### Step 5: Emit static headers in `ClientEmitter.EmitRequestCreation`
+
+In `ClientEmitter.cs`, inside `EmitRequestCreation`, after the `Accept` header line and before the dynamic header params loop:
+
+```csharp
+foreach (var (name, value) in method.StaticHeaders)
+    sb.AppendLine($"        request.Headers.TryAddWithoutValidation(\"{name}\", \"{value}\");");
+```
+
+Also update `EmitMethod` to pass `method.StaticHeaders` — it's part of `method` so no signature change needed there.
+
+### Step 6: Run emission test to verify it passes
+
+```
+dotnet test tests/ZeroAlloc.Rest.Generator.Tests/ -q --filter "StaticHeader_OnMethod_EmittedInGeneratedCode"
+```
+Expected: PASS
+
+### Step 7: Run the full generator test suite
+
+```
+dotnet test tests/ZeroAlloc.Rest.Generator.Tests/ -q
+```
+Expected: All 19 (now 20) tests pass.
+
+### Step 8: Add integration test interface method
+
+In `tests/ZeroAlloc.Rest.Integration.Tests/TestInterfaces/IUserApi.cs`, add to `IUserApi`:
+
+```csharp
+[Get("/users/{id}/raw")]
+[Header("Accept", Value = "application/octet-stream")]
+Task<string> GetUserRawAsync(int id, CancellationToken ct = default);
+```
+
+### Step 9: Write failing integration test
+
+Add to `UserApiTests.cs`:
+
+```csharp
+[Fact]
+public async Task StaticHeader_SentWithRequest()
+{
+    _server.Given(Request.Create()
+                .WithPath("/users/1/raw")
+                .WithHeader("Accept", "application/octet-stream")
+                .UsingGet())
+           .RespondWith(Response.Create()
+               .WithStatusCode(200)
+               .WithHeader("Content-Type", "application/json")
+               .WithBody("\"raw-data\""));
+
+    var result = await _client.GetUserRawAsync(1);
+    Assert.Equal("raw-data", result);
+}
+```
+
+### Step 10: Run integration test to verify it passes
+
+```
+dotnet test tests/ZeroAlloc.Rest.Integration.Tests/ -q --filter "StaticHeader_SentWithRequest"
+```
+Expected: PASS
+
+### Step 11: Commit
+
+```bash
+git add src/ZeroAlloc.Rest.Generator/Models/MethodModel.cs \
+        src/ZeroAlloc.Rest.Generator/ModelExtractor.cs \
+        src/ZeroAlloc.Rest.Generator/ClientEmitter.cs \
+        tests/ZeroAlloc.Rest.Generator.Tests/GeneratorEmissionTests.cs \
+        tests/ZeroAlloc.Rest.Integration.Tests/TestInterfaces/IUserApi.cs \
+        tests/ZeroAlloc.Rest.Integration.Tests/UserApiTests.cs
+git commit -m "feat(generator): emit static [Header] values on methods"
+```
+
+---
+
+## Task 2: Multi-value query parameters (`IEnumerable<T>` with `[Query]`)
+
+Today `[Query] IEnumerable<string> tags` emits `.ToString()` which produces `"System.Collections.Generic.List\`1[…]"`. This task makes it emit repeated `?tags=a&tags=b` pairs.
+
+**Files:**
+- Modify: `src/ZeroAlloc.Rest.Generator/Models/ParameterModel.cs`
+- Modify: `src/ZeroAlloc.Rest.Generator/ModelExtractor.cs`
+- Modify: `src/ZeroAlloc.Rest.Generator/ClientEmitter.cs`
+- Modify: `tests/ZeroAlloc.Rest.Generator.Tests/GeneratorEmissionTests.cs`
+- Modify: `tests/ZeroAlloc.Rest.Integration.Tests/TestInterfaces/IUserApi.cs`
+- Modify: `tests/ZeroAlloc.Rest.Integration.Tests/UserApiTests.cs`
+
+---
+
+### Step 1: Write the failing emission test
+
+Add to `GeneratorEmissionTests.cs`:
+
+```csharp
+[Fact]
+public void QueryParam_Collection_EmitsForEachLoop()
+{
+    var source = """
+        using System.Collections.Generic;
+        using ZeroAlloc.Rest.Attributes;
+        namespace MyApp;
+        [ZeroAllocRestClient]
+        public interface ISearchApi
+        {
+            [Get("/items")]
+            System.Threading.Tasks.Task<string> SearchAsync(
+                [Query] IEnumerable<string> tags,
+                System.Threading.CancellationToken ct = default);
+        }
+        """;
+    var output = GetGeneratedSource(source, "ISearchApi.g.cs");
+    Assert.Contains("foreach", output);
+    Assert.Contains("\"tags=\"", output);
+}
+```
+
+### Step 2: Run test to verify it fails
+
+```
+dotnet test tests/ZeroAlloc.Rest.Generator.Tests/ -q --filter "QueryParam_Collection_EmitsForEachLoop"
+```
+Expected: FAIL
+
+### Step 3: Add `IsCollection` flag to `ParameterModel`
+
+In `src/ZeroAlloc.Rest.Generator/Models/ParameterModel.cs`:
+
+```csharp
+namespace ZeroAlloc.Rest.Generator.Models;
+
+internal enum ParameterKind { Path, Query, Body, FormBody, Header, CancellationToken }
+
+internal record ParameterModel(
+    string Name,
+    string TypeName,
+    ParameterKind Kind,
+    string? HeaderName = null,
+    string? QueryName = null,
+    bool IsNullable = true,
+    bool IsCollection = false);
+```
+
+### Step 4: Detect `IEnumerable<T>` in `ModelExtractor.ExtractParameters`
+
+In `ModelExtractor.cs`, after setting `kind = ParameterKind.Query` and resolving `queryName`, add:
+
+```csharp
+// Detect IEnumerable<T> (but not string — string is IEnumerable<char>)
+bool isCollection = false;
+if (kind == ParameterKind.Query && param.Type.SpecialType != Microsoft.CodeAnalysis.SpecialType.System_String)
+{
+    foreach (var iface in param.Type.AllInterfaces)
+    {
+        if (iface.OriginalDefinition.ToDisplayString() == "System.Collections.Generic.IEnumerable<T>")
+        {
+            isCollection = true;
+            break;
+        }
+    }
+}
+```
+
+Then pass `isCollection` to the `ParameterModel` constructor (last positional arg).
+
+### Step 5: Emit foreach loop in `ClientEmitter.EmitUrlBuilding`
+
+In `ClientEmitter.cs`, inside the `foreach (var q in queryParams)` loop, replace the existing nullable/non-nullable branches with a three-way check:
+
+```csharp
+if (q.IsCollection)
+{
+    sb.AppendLine($"        if ({q.Name} != null)");
+    sb.AppendLine($"        {{");
+    sb.AppendLine($"            foreach (var __item in {q.Name})");
+    sb.AppendLine($"            {{");
+    sb.AppendLine($"                AppendToUrl(urlBuilder, hasQuery ? '&' : '?');");
+    sb.AppendLine($"                AppendToUrl(urlBuilder, \"{q.QueryName}=\".AsSpan());");
+    sb.AppendLine($"                AppendToUrl(urlBuilder, System.Uri.EscapeDataString(__item?.ToString() ?? string.Empty).AsSpan());");
+    sb.AppendLine($"                hasQuery = true;");
+    sb.AppendLine($"            }}");
+    sb.AppendLine($"        }}");
+}
+else if (q.IsNullable)
+{
+    // existing nullable branch
+}
+else
+{
+    // existing non-nullable branch
+}
+```
+
+Also update `hasQueryParams` detection at the top of `Emit` — the `HeapPooledList` using is already triggered by any `ParameterKind.Query`, so no change needed there.
+
+### Step 6: Run emission test to verify it passes
+
+```
+dotnet test tests/ZeroAlloc.Rest.Generator.Tests/ -q --filter "QueryParam_Collection_EmitsForEachLoop"
+```
+Expected: PASS
+
+### Step 7: Run the full generator test suite
+
+```
+dotnet test tests/ZeroAlloc.Rest.Generator.Tests/ -q
+```
+Expected: All tests pass.
+
+### Step 8: Add integration test interface method
+
+In `IUserApi.cs`, add:
+
+```csharp
+[Get("/users")]
+Task<List<UserDto>> ListUsersByTagsAsync([Query] IEnumerable<string> tags, CancellationToken ct = default);
+```
+
+### Step 9: Write failing integration test
+
+Add to `UserApiTests.cs`:
+
+```csharp
+[Fact]
+public async Task ListUsers_WithCollectionQuery_RepeatsKey()
+{
+    _server.Given(Request.Create()
+                .WithPath("/users")
+                .WithParam("tags", "admin", "active")
+                .UsingGet())
+           .RespondWith(Response.Create()
+               .WithStatusCode(200)
+               .WithHeader("Content-Type", "application/json")
+               .WithBody(JsonSerializer.Serialize(new List<UserDto> { new(1, "Alice") }, s_camelCase)));
+
+    var result = await _client.ListUsersByTagsAsync(["admin", "active"]);
+    Assert.Single(result);
+}
+```
+
+### Step 10: Run integration test to verify it passes
+
+```
+dotnet test tests/ZeroAlloc.Rest.Integration.Tests/ -q --filter "ListUsers_WithCollectionQuery_RepeatsKey"
+```
+Expected: PASS
+
+### Step 11: Commit
+
+```bash
+git add src/ZeroAlloc.Rest.Generator/Models/ParameterModel.cs \
+        src/ZeroAlloc.Rest.Generator/ModelExtractor.cs \
+        src/ZeroAlloc.Rest.Generator/ClientEmitter.cs \
+        tests/ZeroAlloc.Rest.Generator.Tests/GeneratorEmissionTests.cs \
+        tests/ZeroAlloc.Rest.Integration.Tests/TestInterfaces/IUserApi.cs \
+        tests/ZeroAlloc.Rest.Integration.Tests/UserApiTests.cs
+git commit -m "feat(generator): support IEnumerable<T> [Query] params as repeated keys"
+```
+
+---
+
+## Task 3: Form-encoded body (`[FormBody]`)
+
+Add a `[FormBody]` attribute that accepts a `Dictionary<string, string>` (or any `IEnumerable<KeyValuePair<string, string>>`). The emitter produces `new FormUrlEncodedContent(param)` — fully AOT-safe, no reflection.
+
+**Files:**
+- Modify: `src/ZeroAlloc.Rest/Attributes/ParameterAttributes.cs`
+- Modify: `src/ZeroAlloc.Rest.Generator/Models/ParameterModel.cs` (add `FormBody` to enum — done in Task 2)
+- Modify: `src/ZeroAlloc.Rest.Generator/ModelExtractor.cs`
+- Modify: `src/ZeroAlloc.Rest.Generator/ClientEmitter.cs`
+- Modify: `tests/ZeroAlloc.Rest.Generator.Tests/GeneratorEmissionTests.cs`
+- Modify: `tests/ZeroAlloc.Rest.Integration.Tests/TestInterfaces/IUserApi.cs`
+- Modify: `tests/ZeroAlloc.Rest.Integration.Tests/UserApiTests.cs`
+
+---
+
+### Step 1: Write the failing emission test
+
+Add to `GeneratorEmissionTests.cs`:
+
+```csharp
+[Fact]
+public void FormBody_EmitsFormUrlEncodedContent()
+{
+    var source = """
+        using System.Collections.Generic;
+        using ZeroAlloc.Rest.Attributes;
+        namespace MyApp;
+        [ZeroAllocRestClient]
+        public interface ITokenApi
+        {
+            [Post("/oauth/token")]
+            System.Threading.Tasks.Task<string> GetTokenAsync(
+                [FormBody] Dictionary<string, string> form,
+                System.Threading.CancellationToken ct = default);
+        }
+        """;
+    var output = GetGeneratedSource(source, "ITokenApi.g.cs");
+    Assert.Contains("FormUrlEncodedContent", output);
+    Assert.DoesNotContain("SerializeAsync", output);
+}
+```
+
+### Step 2: Run test to verify it fails
+
+```
+dotnet test tests/ZeroAlloc.Rest.Generator.Tests/ -q --filter "FormBody_EmitsFormUrlEncodedContent"
+```
+Expected: FAIL — `FormBodyAttribute` doesn't exist yet.
+
+### Step 3: Add `FormBodyAttribute`
+
+In `src/ZeroAlloc.Rest/Attributes/ParameterAttributes.cs`, add:
+
+```csharp
+[AttributeUsage(AttributeTargets.Parameter)]
+public sealed class FormBodyAttribute : Attribute { }
+```
+
+### Step 4: Add `FormBody` to `ParameterKind` (if not done in Task 2)
+
+In `src/ZeroAlloc.Rest.Generator/Models/ParameterModel.cs`, `ParameterKind` should already have `FormBody` from Task 2. Confirm it reads:
+
+```csharp
+internal enum ParameterKind { Path, Query, Body, FormBody, Header, CancellationToken }
+```
+
+### Step 5: Add `FormBodyAttr` constant and detection in `ModelExtractor`
+
+In `ModelExtractor.cs`, add the constant alongside the others:
+
+```csharp
+private const string FormBodyAttr = "ZeroAlloc.Rest.Attributes.FormBodyAttribute";
+```
+
+In `ExtractParameters`, inside the per-attribute loop, add detection after the `BodyAttr` check:
+
+```csharp
+if (attrClass == FormBodyAttr)
+{
+    kind = ParameterKind.FormBody;
+    break;
+}
+```
+
+### Step 6: Emit `FormUrlEncodedContent` in `ClientEmitter.EmitRequestCreation`
+
+In `ClientEmitter.cs`, add a helper to find the form body parameter (alongside `FirstOrDefault` for `Body`):
+
+```csharp
+var formBodyParam = FirstOrDefault(method.Parameters, ParameterKind.FormBody);
+```
+
+Then in `EmitRequestCreation`, add after the existing `bodyParam` block:
+
+```csharp
+if (formBodyParam != null)
+{
+    sb.AppendLine($"        request.Content = new System.Net.Http.FormUrlEncodedContent({formBodyParam.Name});");
+}
+```
+
+And update the `EmitMethod` call to pass `formBodyParam` through — or simply call `FirstOrDefault` inside `EmitRequestCreation` directly since it already receives `method`.
+
+The cleanest change: replace the `bodyParam` parameter with two parameters in `EmitRequestCreation`:
+
+```csharp
+private static void EmitRequestCreation(StringBuilder sb, MethodModel method,
+    List<ParameterModel> headerParams, ParameterModel? bodyParam, ParameterModel? formBodyParam,
+    string ctArg, string serializerExpr)
+```
+
+And in `EmitMethod`:
+
+```csharp
+var formBodyParam = FirstOrDefault(method.Parameters, ParameterKind.FormBody);
+// ...
+EmitRequestCreation(sb, method, headerParams, bodyParam, formBodyParam, ctArg, serializerExpr);
+```
+
+### Step 7: Run emission test to verify it passes
+
+```
+dotnet test tests/ZeroAlloc.Rest.Generator.Tests/ -q --filter "FormBody_EmitsFormUrlEncodedContent"
+```
+Expected: PASS
+
+### Step 8: Run the full generator test suite
+
+```
+dotnet test tests/ZeroAlloc.Rest.Generator.Tests/ -q
+```
+Expected: All tests pass.
+
+### Step 9: Add integration test interface method
+
+In `IUserApi.cs`, add:
+
+```csharp
+[Post("/oauth/token")]
+Task<UserDto> GetTokenAsync([FormBody] Dictionary<string, string> form, CancellationToken ct = default);
+```
+
+### Step 10: Write failing integration test
+
+Add to `UserApiTests.cs`:
+
+```csharp
+[Fact]
+public async Task FormBody_SendsFormEncodedContent()
+{
+    _server.Given(Request.Create()
+                .WithPath("/oauth/token")
+                .WithBody(b => b.Contains("grant_type=client_credentials"))
+                .UsingPost())
+           .RespondWith(Response.Create()
+               .WithStatusCode(200)
+               .WithHeader("Content-Type", "application/json")
+               .WithBody(JsonSerializer.Serialize(new UserDto(1, "token"), s_camelCase)));
+
+    var result = await _client.GetTokenAsync(new Dictionary<string, string>
+    {
+        ["grant_type"] = "client_credentials",
+        ["client_id"] = "my-app"
+    });
+    Assert.Equal(1, result.Id);
+}
+```
+
+### Step 11: Run integration test to verify it passes
+
+```
+dotnet test tests/ZeroAlloc.Rest.Integration.Tests/ -q --filter "FormBody_SendsFormEncodedContent"
+```
+Expected: PASS
+
+### Step 12: Run all tests
+
+```
+dotnet test tests/ -q
+```
+Expected: All tests pass.
+
+### Step 13: Commit
+
+```bash
+git add src/ZeroAlloc.Rest/Attributes/ParameterAttributes.cs \
+        src/ZeroAlloc.Rest.Generator/Models/ParameterModel.cs \
+        src/ZeroAlloc.Rest.Generator/ModelExtractor.cs \
+        src/ZeroAlloc.Rest.Generator/ClientEmitter.cs \
+        tests/ZeroAlloc.Rest.Generator.Tests/GeneratorEmissionTests.cs \
+        tests/ZeroAlloc.Rest.Integration.Tests/TestInterfaces/IUserApi.cs \
+        tests/ZeroAlloc.Rest.Integration.Tests/UserApiTests.cs
+git commit -m "feat(generator): add [FormBody] attribute for form-encoded requests"
+```

--- a/src/ZeroAlloc.Rest.Generator/AnalyzerReleases.Unshipped.md
+++ b/src/ZeroAlloc.Rest.Generator/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,5 @@
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+ZRA001 | ZeroAlloc.Rest.Generator | Error | Conflicting body attributes

--- a/src/ZeroAlloc.Rest.Generator/ClientEmitter.cs
+++ b/src/ZeroAlloc.Rest.Generator/ClientEmitter.cs
@@ -180,6 +180,9 @@ internal static class ClientEmitter
         sb.AppendLine($"            url);");
         sb.AppendLine($"        request.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue({serializerExpr}.ContentType));");
 
+        foreach (var (name, value) in method.StaticHeaders)
+            sb.AppendLine($"        request.Headers.TryAddWithoutValidation(\"{name}\", \"{value}\");");
+
         foreach (var h in headerParams)
             sb.AppendLine($"        request.Headers.TryAddWithoutValidation(\"{h.HeaderName}\", {h.Name}?.ToString());");
 

--- a/src/ZeroAlloc.Rest.Generator/ClientEmitter.cs
+++ b/src/ZeroAlloc.Rest.Generator/ClientEmitter.cs
@@ -150,7 +150,20 @@ internal static class ClientEmitter
             sb.AppendLine("        var hasQuery = false;");
             foreach (var q in queryParams)
             {
-                if (q.IsNullable)
+                if (q.IsCollection)
+                {
+                    sb.AppendLine($"        if ({q.Name} != null)");
+                    sb.AppendLine("        {");
+                    sb.AppendLine($"            foreach (var __item in {q.Name})");
+                    sb.AppendLine("            {");
+                    sb.AppendLine($"                AppendToUrl(urlBuilder, hasQuery ? '&' : '?');");
+                    sb.AppendLine($"                AppendToUrl(urlBuilder, \"{q.QueryName}=\".AsSpan());");
+                    sb.AppendLine($"                AppendToUrl(urlBuilder, System.Uri.EscapeDataString(__item?.ToString() ?? string.Empty).AsSpan());");
+                    sb.AppendLine("                hasQuery = true;");
+                    sb.AppendLine("            }");
+                    sb.AppendLine("        }");
+                }
+                else if (q.IsNullable)
                 {
                     sb.AppendLine($"        if ({q.Name} != null)");
                     sb.AppendLine("        {");

--- a/src/ZeroAlloc.Rest.Generator/ClientEmitter.cs
+++ b/src/ZeroAlloc.Rest.Generator/ClientEmitter.cs
@@ -180,6 +180,10 @@ internal static class ClientEmitter
         sb.AppendLine($"            url);");
         sb.AppendLine($"        request.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue({serializerExpr}.ContentType));");
 
+        // Static headers declared with [Header("Name", Value = "...")] are added additively.
+        // For Accept, this means both the serializer's content type and the static value will
+        // appear in the header. This is intentional — use ConfigureHttpClient to override
+        // the serializer's Accept if exclusive control is needed.
         foreach (var (name, value) in method.StaticHeaders)
             sb.AppendLine($"        request.Headers.TryAddWithoutValidation(\"{name}\", \"{value}\");");
 

--- a/src/ZeroAlloc.Rest.Generator/ClientEmitter.cs
+++ b/src/ZeroAlloc.Rest.Generator/ClientEmitter.cs
@@ -156,9 +156,10 @@ internal static class ClientEmitter
                     sb.AppendLine("        {");
                     sb.AppendLine($"            foreach (var __item in {q.Name})");
                     sb.AppendLine("            {");
+                    sb.AppendLine($"                if (__item == null) continue;");
                     sb.AppendLine($"                AppendToUrl(urlBuilder, hasQuery ? '&' : '?');");
                     sb.AppendLine($"                AppendToUrl(urlBuilder, \"{q.QueryName}=\".AsSpan());");
-                    sb.AppendLine($"                AppendToUrl(urlBuilder, System.Uri.EscapeDataString(__item?.ToString() ?? string.Empty).AsSpan());");
+                    sb.AppendLine($"                AppendToUrl(urlBuilder, System.Uri.EscapeDataString(__item.ToString()!).AsSpan());");
                     sb.AppendLine("                hasQuery = true;");
                     sb.AppendLine("            }");
                     sb.AppendLine("        }");

--- a/src/ZeroAlloc.Rest.Generator/ClientEmitter.cs
+++ b/src/ZeroAlloc.Rest.Generator/ClientEmitter.cs
@@ -104,6 +104,7 @@ internal static class ClientEmitter
         var pathParams = FilterParameters(method.Parameters, ParameterKind.Path);
         var queryParams = FilterParameters(method.Parameters, ParameterKind.Query);
         var bodyParam = FirstOrDefault(method.Parameters, ParameterKind.Body);
+        var formBodyParam = FirstOrDefault(method.Parameters, ParameterKind.FormBody);
         var headerParams = FilterParameters(method.Parameters, ParameterKind.Header);
 
         // If the method has its own [Serializer], use that injected field; otherwise fall back to _serializer.
@@ -117,7 +118,7 @@ internal static class ClientEmitter
         sb.AppendLine("    {");
 
         EmitUrlBuilding(sb, method.Route, pathParams, queryParams);
-        EmitRequestCreation(sb, method, headerParams, bodyParam, ctArg, serializerExpr);
+        EmitRequestCreation(sb, method, headerParams, bodyParam, formBodyParam, ctArg, serializerExpr);
         EmitSendAndResponse(sb, method, ctArg, serializerExpr);
 
         sb.AppendLine("    }");
@@ -187,7 +188,8 @@ internal static class ClientEmitter
     }
 
     private static void EmitRequestCreation(StringBuilder sb, MethodModel method,
-        List<ParameterModel> headerParams, ParameterModel? bodyParam, string ctArg, string serializerExpr)
+        List<ParameterModel> headerParams, ParameterModel? bodyParam, ParameterModel? formBodyParam,
+        string ctArg, string serializerExpr)
     {
         sb.AppendLine($"        using var request = new System.Net.Http.HttpRequestMessage(");
         sb.AppendLine($"            System.Net.Http.HttpMethod.{Capitalize(method.HttpMethod)},");
@@ -219,6 +221,11 @@ internal static class ClientEmitter
             sb.AppendLine("        bodyStream.Position = 0;");
             sb.AppendLine("        request.Content = new System.Net.Http.StreamContent(bodyStream);");
             sb.AppendLine($"        request.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue({serializerExpr}.ContentType);");
+        }
+
+        if (formBodyParam != null)
+        {
+            sb.AppendLine($"        request.Content = new System.Net.Http.FormUrlEncodedContent({formBodyParam.Name});");
         }
     }
 

--- a/src/ZeroAlloc.Rest.Generator/ClientEmitter.cs
+++ b/src/ZeroAlloc.Rest.Generator/ClientEmitter.cs
@@ -7,6 +7,14 @@ namespace ZeroAlloc.Rest.Generator;
 
 internal static class ClientEmitter
 {
+    private static readonly DiagnosticDescriptor s_conflictingBodyDescriptor = new DiagnosticDescriptor(
+        id: "ZRA001",
+        title: "Conflicting body attributes",
+        messageFormat: "Method '{0}' has both [Body] and [FormBody] parameters; only one is allowed",
+        category: "ZeroAlloc.Rest.Generator",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
     internal static void Emit(SourceProductionContext ctx, ClientModel model)
     {
         // Collect unique method-level serializer types (ordered, deduped)
@@ -80,7 +88,7 @@ internal static class ClientEmitter
         sb.AppendLine();
 
         foreach (var method in model.Methods)
-            EmitMethod(sb, method, serializerFieldMap);
+            EmitMethod(ctx, sb, method, serializerFieldMap);
 
         if (hasQueryParams)
         {
@@ -97,7 +105,7 @@ internal static class ClientEmitter
         ctx.AddSource($"{model.InterfaceName}.g.cs", sb.ToString());
     }
 
-    private static void EmitMethod(StringBuilder sb, MethodModel method, IReadOnlyDictionary<string, string> serializerFieldMap)
+    private static void EmitMethod(SourceProductionContext ctx, StringBuilder sb, MethodModel method, IReadOnlyDictionary<string, string> serializerFieldMap)
     {
         var ctParam = FindCancellationToken(method.Parameters);
         var ctArg = ctParam != null ? ctParam.Name : "default";
@@ -106,6 +114,13 @@ internal static class ClientEmitter
         var bodyParam = FirstOrDefault(method.Parameters, ParameterKind.Body);
         var formBodyParam = FirstOrDefault(method.Parameters, ParameterKind.FormBody);
         var headerParams = FilterParameters(method.Parameters, ParameterKind.Header);
+
+        if (bodyParam != null && formBodyParam != null)
+        {
+            ctx.ReportDiagnostic(Diagnostic.Create(s_conflictingBodyDescriptor, Location.None, method.Name));
+            // Still emit valid (if incomplete) code so compilation continues
+            formBodyParam = null; // suppress the FormBody branch
+        }
 
         // If the method has its own [Serializer], use that injected field; otherwise fall back to _serializer.
         var serializerExpr = method.SerializerTypeName != null && serializerFieldMap.TryGetValue(method.SerializerTypeName, out var fieldName)

--- a/src/ZeroAlloc.Rest.Generator/ModelExtractor.cs
+++ b/src/ZeroAlloc.Rest.Generator/ModelExtractor.cs
@@ -171,7 +171,32 @@ internal static class ModelExtractor
             // Nullable value types (int?) have OriginalDefinition == System.Nullable<T>.
             bool isNullable = !param.Type.IsValueType
                 || param.Type.OriginalDefinition.SpecialType == Microsoft.CodeAnalysis.SpecialType.System_Nullable_T;
-            result.Add(new ParameterModel(param.Name, typeName, kind, headerName, queryName ?? param.Name, isNullable));
+
+            bool isCollection = false;
+            if (kind == ParameterKind.Query
+                && param.Type.SpecialType != Microsoft.CodeAnalysis.SpecialType.System_String)
+            {
+                // Check if the type itself is IEnumerable<T>
+                if (param.Type is INamedTypeSymbol namedParamType
+                    && namedParamType.OriginalDefinition.ToDisplayString() == "System.Collections.Generic.IEnumerable<T>")
+                {
+                    isCollection = true;
+                }
+                else
+                {
+                    // Check if it implements IEnumerable<T>
+                    foreach (var iface in param.Type.AllInterfaces)
+                    {
+                        if (iface.OriginalDefinition.ToDisplayString() == "System.Collections.Generic.IEnumerable<T>")
+                        {
+                            isCollection = true;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            result.Add(new ParameterModel(param.Name, typeName, kind, headerName, queryName ?? param.Name, isNullable, isCollection));
         }
         return result.AsReadOnly();
     }

--- a/src/ZeroAlloc.Rest.Generator/ModelExtractor.cs
+++ b/src/ZeroAlloc.Rest.Generator/ModelExtractor.cs
@@ -65,6 +65,26 @@ internal static class ModelExtractor
             if (attrClass == DeleteAttr && attr.ConstructorArguments.Length > 0) { httpMethod = "DELETE"; route = (string?)attr.ConstructorArguments[0].Value; break; }
         }
 
+        var staticHeaders = new List<(string, string)>();
+        foreach (var attr in method.GetAttributes())
+        {
+            if (attr.AttributeClass?.ToDisplayString() != HeaderAttr) continue;
+            if (attr.ConstructorArguments.Length == 0) continue;
+            var headerName = attr.ConstructorArguments[0].Value as string;
+            if (headerName is null) continue;
+            string? headerValue = null;
+            foreach (var namedArg in attr.NamedArguments)
+            {
+                if (namedArg.Key == "Value" && namedArg.Value.Value is string v)
+                {
+                    headerValue = v;
+                    break;
+                }
+            }
+            if (headerValue != null)
+                staticHeaders.Add((headerName, headerValue));
+        }
+
         if (httpMethod is null || route is null) return null;
 
         var returnType = method.ReturnType as INamedTypeSymbol;
@@ -94,7 +114,7 @@ internal static class ModelExtractor
         return new MethodModel(
             method.Name, httpMethod, route, returnTypeName,
             innerTypeName, returnsResult, returnsVoid,
-            parameters, methodSerializer);
+            parameters, methodSerializer, staticHeaders.AsReadOnly());
     }
 
     private static IReadOnlyList<ParameterModel> ExtractParameters(IMethodSymbol method)

--- a/src/ZeroAlloc.Rest.Generator/ModelExtractor.cs
+++ b/src/ZeroAlloc.Rest.Generator/ModelExtractor.cs
@@ -12,7 +12,8 @@ internal static class ModelExtractor
     private const string PutAttr    = "ZeroAlloc.Rest.Attributes.PutAttribute";
     private const string PatchAttr  = "ZeroAlloc.Rest.Attributes.PatchAttribute";
     private const string DeleteAttr = "ZeroAlloc.Rest.Attributes.DeleteAttribute";
-    private const string BodyAttr   = "ZeroAlloc.Rest.Attributes.BodyAttribute";
+    private const string BodyAttr     = "ZeroAlloc.Rest.Attributes.BodyAttribute";
+    private const string FormBodyAttr = "ZeroAlloc.Rest.Attributes.FormBodyAttribute";
     private const string QueryAttr  = "ZeroAlloc.Rest.Attributes.QueryAttribute";
     private const string HeaderAttr = "ZeroAlloc.Rest.Attributes.HeaderAttribute";
     private const string SerializerAttr = "ZeroAlloc.Rest.Attributes.SerializerAttribute";
@@ -140,6 +141,11 @@ internal static class ModelExtractor
                 if (attrClass == BodyAttr)
                 {
                     kind = ParameterKind.Body;
+                    break;
+                }
+                if (attrClass == FormBodyAttr)
+                {
+                    kind = ParameterKind.FormBody;
                     break;
                 }
                 if (attrClass == QueryAttr)

--- a/src/ZeroAlloc.Rest.Generator/ModelExtractor.cs
+++ b/src/ZeroAlloc.Rest.Generator/ModelExtractor.cs
@@ -82,6 +82,9 @@ internal static class ModelExtractor
                     break;
                 }
             }
+            // A method-level [Header] without a Value is intentionally ignored — there is nothing
+            // to emit at compile time. Users who omit Value get no output and no diagnostic.
+            // Consider adding ZRA002 here in future to warn about this silent no-op.
             if (headerValue != null)
                 staticHeaders.Add((headerName, headerValue));
         }

--- a/src/ZeroAlloc.Rest.Generator/Models/MethodModel.cs
+++ b/src/ZeroAlloc.Rest.Generator/Models/MethodModel.cs
@@ -11,4 +11,5 @@ internal record MethodModel(
     bool ReturnsResult,
     bool ReturnsVoid,
     IReadOnlyList<ParameterModel> Parameters,
-    string? SerializerTypeName);
+    string? SerializerTypeName,
+    IReadOnlyList<(string Name, string Value)> StaticHeaders);

--- a/src/ZeroAlloc.Rest.Generator/Models/ParameterModel.cs
+++ b/src/ZeroAlloc.Rest.Generator/Models/ParameterModel.cs
@@ -1,6 +1,6 @@
 namespace ZeroAlloc.Rest.Generator.Models;
 
-internal enum ParameterKind { Path, Query, Body, Header, CancellationToken }
+internal enum ParameterKind { Path, Query, Body, FormBody, Header, CancellationToken }
 
 internal record ParameterModel(
     string Name,

--- a/src/ZeroAlloc.Rest.Generator/Models/ParameterModel.cs
+++ b/src/ZeroAlloc.Rest.Generator/Models/ParameterModel.cs
@@ -8,4 +8,5 @@ internal record ParameterModel(
     ParameterKind Kind,
     string? HeaderName = null,
     string? QueryName = null,
-    bool IsNullable = true);
+    bool IsNullable = true,
+    bool IsCollection = false);

--- a/src/ZeroAlloc.Rest.Generator/ZeroAlloc.Rest.Generator.csproj
+++ b/src/ZeroAlloc.Rest.Generator/ZeroAlloc.Rest.Generator.csproj
@@ -8,4 +8,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
   </ItemGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
+    <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
+  </ItemGroup>
 </Project>

--- a/src/ZeroAlloc.Rest/Attributes/ParameterAttributes.cs
+++ b/src/ZeroAlloc.Rest/Attributes/ParameterAttributes.cs
@@ -16,6 +16,9 @@ public sealed class HeaderAttribute(string name) : Attribute
     public string? Value { get; init; }
 }
 
+[AttributeUsage(AttributeTargets.Parameter)]
+public sealed class FormBodyAttribute : Attribute { }
+
 [AttributeUsage(AttributeTargets.Interface | AttributeTargets.Method)]
 public sealed class SerializerAttribute(Type serializerType) : Attribute
 {

--- a/src/ZeroAlloc.Rest/Attributes/ParameterAttributes.cs
+++ b/src/ZeroAlloc.Rest/Attributes/ParameterAttributes.cs
@@ -13,9 +13,21 @@ public sealed class QueryAttribute : Attribute
 public sealed class HeaderAttribute(string name) : Attribute
 {
     public string Name { get; } = name;
+    /// <summary>
+    /// When set on a <b>method</b>, emits a compile-time static header with this value.
+    /// When used on a <b>parameter</b>, this property is ignored — the parameter value is used at runtime.
+    /// If <see cref="Value"/> is <see langword="null"/> on a method-level attribute, the attribute is silently ignored.
+    /// </summary>
     public string? Value { get; init; }
 }
 
+/// <summary>
+/// Marks a parameter as the form-encoded body of the request.
+/// The parameter type must be assignable to <see cref="System.Collections.Generic.IEnumerable{T}"/> of
+/// <see cref="System.Collections.Generic.KeyValuePair{TKey,TValue}"/> (e.g. <c>Dictionary&lt;string, string&gt;</c>).
+/// The generated client emits <c>FormUrlEncodedContent</c> directly — no serializer is used.
+/// Only one of <see cref="BodyAttribute"/> or <see cref="FormBodyAttribute"/> may appear on a single method.
+/// </summary>
 [AttributeUsage(AttributeTargets.Parameter)]
 public sealed class FormBodyAttribute : Attribute { }
 

--- a/tests/ZeroAlloc.Rest.Generator.Tests/GeneratorEmissionTests.cs
+++ b/tests/ZeroAlloc.Rest.Generator.Tests/GeneratorEmissionTests.cs
@@ -270,6 +270,27 @@ public class GeneratorEmissionTests
         Assert.Contains("TryAddWithoutValidation", output);
     }
 
+    [Fact]
+    public void QueryParam_Collection_EmitsForEachLoop()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using ZeroAlloc.Rest.Attributes;
+            namespace MyApp;
+            [ZeroAllocRestClient]
+            public interface ISearchApi
+            {
+                [Get("/items")]
+                System.Threading.Tasks.Task<string> SearchAsync(
+                    [Query] IEnumerable<string> tags,
+                    System.Threading.CancellationToken ct = default);
+            }
+            """;
+        var output = GetGeneratedSource(source, "ISearchApi.g.cs");
+        Assert.Contains("foreach", output);
+        Assert.Contains("\"tags=\"", output);
+    }
+
     private static string GetGeneratedSource(string source, string hintName)
     {
         var compilation = CSharpCompilation.Create(

--- a/tests/ZeroAlloc.Rest.Generator.Tests/GeneratorEmissionTests.cs
+++ b/tests/ZeroAlloc.Rest.Generator.Tests/GeneratorEmissionTests.cs
@@ -289,6 +289,29 @@ public class GeneratorEmissionTests
         var output = GetGeneratedSource(source, "ISearchApi.g.cs");
         Assert.Contains("foreach", output);
         Assert.Contains("\"tags=\"", output);
+        Assert.Contains("EscapeDataString", output);
+    }
+
+    [Fact]
+    public void QueryParam_EmptyCollection_ProducesNoQueryString()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using ZeroAlloc.Rest.Attributes;
+            namespace MyApp;
+            [ZeroAllocRestClient]
+            public interface ISearchApi
+            {
+                [Get("/items")]
+                System.Threading.Tasks.Task<string> SearchAsync(
+                    [Query] IEnumerable<string>? tags,
+                    System.Threading.CancellationToken ct = default);
+            }
+            """;
+        var output = GetGeneratedSource(source, "ISearchApi.g.cs");
+        // The foreach branch must guard null items — no unconditional emission of empty values
+        Assert.Contains("if (__item == null) continue;", output);
+        Assert.DoesNotContain("__item?.ToString() ?? string.Empty", output);
     }
 
     private static string GetGeneratedSource(string source, string hintName)

--- a/tests/ZeroAlloc.Rest.Generator.Tests/GeneratorEmissionTests.cs
+++ b/tests/ZeroAlloc.Rest.Generator.Tests/GeneratorEmissionTests.cs
@@ -333,6 +333,41 @@ public class GeneratorEmissionTests
         var output = GetGeneratedSource(source, "ITokenApi.g.cs");
         Assert.Contains("FormUrlEncodedContent", output);
         Assert.DoesNotContain("SerializeAsync", output);
+        Assert.DoesNotContain("StreamContent", output);
+    }
+
+    [Fact]
+    public void ConflictingBodyAndFormBody_ReportsDiagnostic()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using ZeroAlloc.Rest.Attributes;
+            namespace MyApp;
+            [ZeroAllocRestClient]
+            public interface ITokenApi
+            {
+                [Post("/token")]
+                System.Threading.Tasks.Task<string> BadAsync(
+                    [Body] string body,
+                    [FormBody] Dictionary<string, string> form,
+                    System.Threading.CancellationToken ct = default);
+            }
+            """;
+        var compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            new[] { CSharpSyntaxTree.ParseText(source) },
+            Basic.Reference.Assemblies.Net100.References.All
+                .Append(MetadataReference.CreateFromFile(AttributesAssembly.Location)),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var generator = new RestClientGenerator();
+        var driver = CSharpGeneratorDriver
+            .Create(generator)
+            .RunGenerators(compilation);
+
+        var result = driver.GetRunResult();
+        var diagnostics = result.Results[0].Diagnostics;
+        Assert.Contains(diagnostics, d => d.Id == "ZRA001");
     }
 
     private static string GetGeneratedSource(string source, string hintName)

--- a/tests/ZeroAlloc.Rest.Generator.Tests/GeneratorEmissionTests.cs
+++ b/tests/ZeroAlloc.Rest.Generator.Tests/GeneratorEmissionTests.cs
@@ -314,6 +314,27 @@ public class GeneratorEmissionTests
         Assert.DoesNotContain("__item?.ToString() ?? string.Empty", output);
     }
 
+    [Fact]
+    public void FormBody_EmitsFormUrlEncodedContent()
+    {
+        var source = """
+            using System.Collections.Generic;
+            using ZeroAlloc.Rest.Attributes;
+            namespace MyApp;
+            [ZeroAllocRestClient]
+            public interface ITokenApi
+            {
+                [Post("/oauth/token")]
+                System.Threading.Tasks.Task<string> GetTokenAsync(
+                    [FormBody] Dictionary<string, string> form,
+                    System.Threading.CancellationToken ct = default);
+            }
+            """;
+        var output = GetGeneratedSource(source, "ITokenApi.g.cs");
+        Assert.Contains("FormUrlEncodedContent", output);
+        Assert.DoesNotContain("SerializeAsync", output);
+    }
+
     private static string GetGeneratedSource(string source, string hintName)
     {
         var compilation = CSharpCompilation.Create(

--- a/tests/ZeroAlloc.Rest.Generator.Tests/GeneratorEmissionTests.cs
+++ b/tests/ZeroAlloc.Rest.Generator.Tests/GeneratorEmissionTests.cs
@@ -250,6 +250,26 @@ public class GeneratorEmissionTests
         Assert.Contains(".Failure(", output);
     }
 
+    [Fact]
+    public void StaticHeader_OnMethod_EmittedInGeneratedCode()
+    {
+        var source = """
+            using ZeroAlloc.Rest.Attributes;
+            namespace MyApp;
+            [ZeroAllocRestClient]
+            public interface IFileApi
+            {
+                [Get("/files/{id}")]
+                [Header("Accept", Value = "application/octet-stream")]
+                System.Threading.Tasks.Task<string> GetFileAsync(int id, System.Threading.CancellationToken ct = default);
+            }
+            """;
+        var output = GetGeneratedSource(source, "IFileApi.g.cs");
+        Assert.Contains("\"Accept\"", output);
+        Assert.Contains("\"application/octet-stream\"", output);
+        Assert.Contains("TryAddWithoutValidation", output);
+    }
+
     private static string GetGeneratedSource(string source, string hintName)
     {
         var compilation = CSharpCompilation.Create(

--- a/tests/ZeroAlloc.Rest.Integration.Tests/TestInterfaces/IUserApi.cs
+++ b/tests/ZeroAlloc.Rest.Integration.Tests/TestInterfaces/IUserApi.cs
@@ -31,4 +31,7 @@ public interface IUserApi
     [Get("/users/{id}/raw")]
     [Header("Accept", Value = "application/octet-stream")]
     Task<string> GetUserRawAsync(int id, CancellationToken ct = default);
+
+    [Post("/oauth/token")]
+    Task<UserDto> GetTokenAsync([FormBody] Dictionary<string, string> form, CancellationToken ct = default);
 }

--- a/tests/ZeroAlloc.Rest.Integration.Tests/TestInterfaces/IUserApi.cs
+++ b/tests/ZeroAlloc.Rest.Integration.Tests/TestInterfaces/IUserApi.cs
@@ -26,7 +26,7 @@ public interface IUserApi
     Task DeleteUserAsync(int id, CancellationToken ct = default);
 
     [Get("/users")]
-    Task<List<UserDto>> ListUsersByTagsAsync([Query] IEnumerable<string> tags, CancellationToken ct = default);
+    Task<List<UserDto>> ListUsersByTagsAsync([Query] IEnumerable<string>? tags, CancellationToken ct = default);
 
     [Get("/users/{id}/raw")]
     [Header("Accept", Value = "application/octet-stream")]

--- a/tests/ZeroAlloc.Rest.Integration.Tests/TestInterfaces/IUserApi.cs
+++ b/tests/ZeroAlloc.Rest.Integration.Tests/TestInterfaces/IUserApi.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using ZeroAlloc.Rest.Attributes;
 using ZeroAlloc.Results;
 
@@ -23,6 +24,9 @@ public interface IUserApi
 
     [Delete("/users/{id}")]
     Task DeleteUserAsync(int id, CancellationToken ct = default);
+
+    [Get("/users")]
+    Task<List<UserDto>> ListUsersByTagsAsync([Query] IEnumerable<string> tags, CancellationToken ct = default);
 
     [Get("/users/{id}/raw")]
     [Header("Accept", Value = "application/octet-stream")]

--- a/tests/ZeroAlloc.Rest.Integration.Tests/TestInterfaces/IUserApi.cs
+++ b/tests/ZeroAlloc.Rest.Integration.Tests/TestInterfaces/IUserApi.cs
@@ -23,4 +23,8 @@ public interface IUserApi
 
     [Delete("/users/{id}")]
     Task DeleteUserAsync(int id, CancellationToken ct = default);
+
+    [Get("/users/{id}/raw")]
+    [Header("Accept", Value = "application/octet-stream")]
+    Task<string> GetUserRawAsync(int id, CancellationToken ct = default);
 }

--- a/tests/ZeroAlloc.Rest.Integration.Tests/UserApiTests.cs
+++ b/tests/ZeroAlloc.Rest.Integration.Tests/UserApiTests.cs
@@ -111,6 +111,22 @@ public sealed class UserApiTests : IDisposable
         Assert.Equal(HttpStatusCode.NotFound, result.Error.StatusCode);
     }
 
+    [Fact]
+    public async Task StaticHeader_SentWithRequest()
+    {
+        _server.Given(Request.Create()
+                    .WithPath("/users/1/raw")
+                    .WithHeader("Accept", "*application/octet-stream*")
+                    .UsingGet())
+               .RespondWith(Response.Create()
+                   .WithStatusCode(200)
+                   .WithHeader("Content-Type", "application/json")
+                   .WithBody("\"raw-data\""));
+
+        var result = await _client.GetUserRawAsync(1);
+        Assert.Equal("raw-data", result);
+    }
+
     public void Dispose()
     {
         _provider.Dispose();

--- a/tests/ZeroAlloc.Rest.Integration.Tests/UserApiTests.cs
+++ b/tests/ZeroAlloc.Rest.Integration.Tests/UserApiTests.cs
@@ -125,6 +125,10 @@ public sealed class UserApiTests : IDisposable
 
         var result = await _client.GetUserRawAsync(1);
         Assert.Equal("raw-data", result);
+
+        var logEntry = _server.LogEntries.Single(e => string.Equals(e.RequestMessage?.Path, "/users/1/raw", StringComparison.Ordinal));
+        var acceptValues = string.Join(", ", logEntry.RequestMessage!.Headers!["Accept"]);
+        Assert.Contains("application/octet-stream", acceptValues, StringComparison.Ordinal);
     }
 
     public void Dispose()

--- a/tests/ZeroAlloc.Rest.Integration.Tests/UserApiTests.cs
+++ b/tests/ZeroAlloc.Rest.Integration.Tests/UserApiTests.cs
@@ -131,6 +131,23 @@ public sealed class UserApiTests : IDisposable
         Assert.Contains("application/octet-stream", acceptValues, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task ListUsers_WithCollectionQuery_RepeatsKey()
+    {
+        _server.Given(Request.Create()
+                    .WithPath("/users")
+                    .WithParam("tags", "admin", "active")
+                    .UsingGet())
+               .RespondWith(Response.Create()
+                   .WithStatusCode(200)
+                   .WithHeader("Content-Type", "application/json")
+                   .WithBody(JsonSerializer.Serialize(new List<UserDto> { new(1, "Alice") }, s_camelCase)));
+
+        var result = await _client.ListUsersByTagsAsync(["admin", "active"]);
+        Assert.Single(result);
+        Assert.Equal("Alice", result[0].Name);
+    }
+
     public void Dispose()
     {
         _provider.Dispose();

--- a/tests/ZeroAlloc.Rest.Integration.Tests/UserApiTests.cs
+++ b/tests/ZeroAlloc.Rest.Integration.Tests/UserApiTests.cs
@@ -143,7 +143,7 @@ public sealed class UserApiTests : IDisposable
                    .WithHeader("Content-Type", "application/json")
                    .WithBody(JsonSerializer.Serialize(new List<UserDto> { new(1, "Alice") }, s_camelCase)));
 
-        var result = await _client.ListUsersByTagsAsync(["admin", "active"]);
+        var result = await _client.ListUsersByTagsAsync(new List<string> { "admin", "active" });
         Assert.Single(result);
         Assert.Equal("Alice", result[0].Name);
     }

--- a/tests/ZeroAlloc.Rest.Integration.Tests/UserApiTests.cs
+++ b/tests/ZeroAlloc.Rest.Integration.Tests/UserApiTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Net;
 using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json;
@@ -146,6 +147,26 @@ public sealed class UserApiTests : IDisposable
         var result = await _client.ListUsersByTagsAsync(new List<string> { "admin", "active" });
         Assert.Single(result);
         Assert.Equal("Alice", result[0].Name);
+    }
+
+    [Fact]
+    public async Task FormBody_SendsFormEncodedContent()
+    {
+        _server.Given(Request.Create()
+                    .WithPath("/oauth/token")
+                    .WithBody(b => b != null && b.Contains("grant_type=client_credentials", StringComparison.Ordinal))
+                    .UsingPost())
+               .RespondWith(Response.Create()
+                   .WithStatusCode(200)
+                   .WithHeader("Content-Type", "application/json")
+                   .WithBody(JsonSerializer.Serialize(new UserDto(1, "token"), s_camelCase)));
+
+        var result = await _client.GetTokenAsync(new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["grant_type"] = "client_credentials",
+            ["client_id"] = "my-app"
+        });
+        Assert.Equal(1, result.Id);
     }
 
     public void Dispose()

--- a/tests/ZeroAlloc.Rest.Integration.Tests/UserApiTests.cs
+++ b/tests/ZeroAlloc.Rest.Integration.Tests/UserApiTests.cs
@@ -167,6 +167,10 @@ public sealed class UserApiTests : IDisposable
             ["client_id"] = "my-app"
         });
         Assert.Equal(1, result.Id);
+        var logEntry = _server.LogEntries.Single(e =>
+            string.Equals(e.RequestMessage?.Path, "/oauth/token", StringComparison.Ordinal));
+        var contentType = string.Join(", ", logEntry.RequestMessage!.Headers!["Content-Type"]);
+        Assert.Contains("application/x-www-form-urlencoded", contentType, StringComparison.Ordinal);
     }
 
     public void Dispose()

--- a/tests/ZeroAlloc.Rest.Tests/Attributes/AttributeTests.cs
+++ b/tests/ZeroAlloc.Rest.Tests/Attributes/AttributeTests.cs
@@ -62,4 +62,19 @@ public class AttributeTests
         var attr = new SerializerAttribute(typeof(object));
         Assert.Equal(typeof(object), attr.SerializerType);
     }
+
+    [Fact]
+    public void HeaderAttribute_StoresStaticValue()
+    {
+        var attr = new HeaderAttribute("Accept") { Value = "application/octet-stream" };
+        Assert.Equal("Accept", attr.Name);
+        Assert.Equal("application/octet-stream", attr.Value);
+    }
+
+    [Fact]
+    public void FormBodyAttribute_IsAnAttribute()
+    {
+        var attr = new FormBodyAttribute();
+        Assert.IsAssignableFrom<Attribute>(attr);
+    }
 }


### PR DESCRIPTION
## Summary

- **Static `[Header]` on methods** — `[Header("Accept", Value = "application/octet-stream")]` on an interface method now emits a compile-time `TryAddWithoutValidation` call; the `Value` property was previously parsed by the attribute but ignored by the generator
- **Multi-value `[Query]` collections** — `[Query] IEnumerable<T>?` parameters now emit a `foreach` loop producing repeated keys (`?tags=a&tags=b`); null items are skipped
- **`[FormBody]` attribute** — new attribute that emits `FormUrlEncodedContent(param)` instead of the serializer, for OAuth token endpoints and form-encoded APIs; combining `[Body]` and `[FormBody]` on the same method reports diagnostic `ZRA001`

## Test Plan
- [ ] 25/25 generator emission tests pass
- [ ] 9/9 integration tests pass (WireMock-backed)
- [ ] 33/33 unit tests pass
- [ ] 11/11 tools tests pass
- [ ] `docs/parameters.md` updated with all three features
- [ ] XML doc comments added to `FormBodyAttribute` and `HeaderAttribute.Value`