### PR TITLE
ci: add AOT publish smoke test (item 1 of #40)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,31 @@ jobs:
             --api-key ${{ secrets.NUGET_API_KEY }} \
             --source https://api.nuget.org/v3/index.json \
             --skip-duplicate
+
+  aot-smoke:
+    runs-on: ubuntu-latest
+    # Publishes samples/ZeroAlloc.Rest.AotSmoke with PublishAot=true. Verifies the
+    # generator-emitted REST client type survives ILC (implements IUserApi, loadable
+    # via Type.GetType). End-to-end HTTP + serializer flow is covered by the
+    # integration tests; this smoke is the AOT guarantee.
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Install AOT native toolchain
+        run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
+
+      - name: Restore
+        run: dotnet restore samples/ZeroAlloc.Rest.AotSmoke/ZeroAlloc.Rest.AotSmoke.csproj
+
+      - name: Publish AOT
+        run: dotnet publish samples/ZeroAlloc.Rest.AotSmoke/ZeroAlloc.Rest.AotSmoke.csproj -r linux-x64 -c Release -o ./aot-out
+
+      - name: Run AOT binary
+        run: ./aot-out/ZeroAlloc.Rest.AotSmoke

--- a/ZeroAlloc.Rest.slnx
+++ b/ZeroAlloc.Rest.slnx
@@ -7,6 +7,9 @@
     <Project Path="src/ZeroAlloc.Rest.MessagePack/ZeroAlloc.Rest.MessagePack.csproj" />
     <Project Path="src/ZeroAlloc.Rest.Tools/ZeroAlloc.Rest.Tools.csproj" />
   </Folder>
+  <Folder Name="/samples/">
+    <Project Path="samples/ZeroAlloc.Rest.AotSmoke/ZeroAlloc.Rest.AotSmoke.csproj" />
+  </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/ZeroAlloc.Rest.Tests/ZeroAlloc.Rest.Tests.csproj" />
     <Project Path="tests/ZeroAlloc.Rest.Generator.Tests/ZeroAlloc.Rest.Generator.Tests.csproj" />

--- a/samples/ZeroAlloc.Rest.AotSmoke/IUserApi.cs
+++ b/samples/ZeroAlloc.Rest.AotSmoke/IUserApi.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using ZeroAlloc.Rest.Attributes;
@@ -7,6 +8,13 @@ namespace ZeroAlloc.Rest.AotSmoke;
 [ZeroAllocRestClient]
 public interface IUserApi
 {
+    // The generator-emitted UserApiClient.GetUserAsync carries
+    // [Requires{Dynamic,Unreferenced}Code] — the interface must match or
+    // ILC raises IL3051/IL2046. Tracked as #42: the generator should emit
+    // [UnconditionalSuppressMessage] instead so consumers don't have to
+    // propagate the Requires annotations to every caller.
     [Get("/users/{id}")]
+    [RequiresDynamicCode("Generated client may deserialise via reflection.")]
+    [RequiresUnreferencedCode("Generated client may deserialise via reflection.")]
     Task<string?> GetUserAsync(int id, CancellationToken ct = default);
 }

--- a/samples/ZeroAlloc.Rest.AotSmoke/IUserApi.cs
+++ b/samples/ZeroAlloc.Rest.AotSmoke/IUserApi.cs
@@ -1,0 +1,12 @@
+using System.Threading;
+using System.Threading.Tasks;
+using ZeroAlloc.Rest.Attributes;
+
+namespace ZeroAlloc.Rest.AotSmoke;
+
+[ZeroAllocRestClient]
+public interface IUserApi
+{
+    [Get("/users/{id}")]
+    Task<string?> GetUserAsync(int id, CancellationToken ct = default);
+}

--- a/samples/ZeroAlloc.Rest.AotSmoke/Program.cs
+++ b/samples/ZeroAlloc.Rest.AotSmoke/Program.cs
@@ -1,0 +1,34 @@
+using System;
+using ZeroAlloc.Rest.AotSmoke;
+
+// Verify that the generator-emitted UserApiClient type (emitted for the
+// [ZeroAllocRestClient] interface) compiles and publishes cleanly under
+// PublishAot=true. We don't fire an actual HTTP request — that path requires
+// an IRestSerializer + HttpClient setup that duplicates the integration tests.
+// The compile-time guarantee (ILC analyses the emitted proxy) is the AOT signal
+// we want from this smoke.
+
+if (typeof(IUserApi) is null)
+{
+    Console.Error.WriteLine("AOT smoke: FAIL — IUserApi type should be resolvable");
+    return 1;
+}
+
+// The generator emits a UserApiClient implementation. Its existence in the
+// compiled assembly is what ILC analyses; referencing it here forces the
+// linker to keep the type alive during trim.
+var clientType = Type.GetType("ZeroAlloc.Rest.AotSmoke.UserApiClient");
+if (clientType is null)
+{
+    Console.Error.WriteLine("AOT smoke: FAIL — generator-emitted UserApiClient type not found");
+    return 1;
+}
+
+if (!typeof(IUserApi).IsAssignableFrom(clientType))
+{
+    Console.Error.WriteLine("AOT smoke: FAIL — UserApiClient should implement IUserApi");
+    return 1;
+}
+
+Console.WriteLine("AOT smoke: PASS");
+return 0;

--- a/samples/ZeroAlloc.Rest.AotSmoke/ZeroAlloc.Rest.AotSmoke.csproj
+++ b/samples/ZeroAlloc.Rest.AotSmoke/ZeroAlloc.Rest.AotSmoke.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>ZeroAlloc.Rest.AotSmoke</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <PublishAot>true</PublishAot>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <OptimizationPreference>Size</OptimizationPreference>
+
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <WarningsAsErrors>$(WarningsAsErrors);IL2026;IL2067;IL2075;IL2091;IL3050;IL3051</WarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ZeroAlloc.Rest\ZeroAlloc.Rest.csproj" />
+    <ProjectReference Include="..\..\src\ZeroAlloc.Rest.Generator\ZeroAlloc.Rest.Generator.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false"
+                      UndefineProperties="PublishAot" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
First item of #40. Verifies the generator-emitted `UserApiClient` survives ILC under `PublishAot=true`.