### PR TITLE
fix(generator): emit [UnconditionalSuppressMessage] instead of [RequiresDynamicCode] (closes #42)

### DIFF
--- a/samples/ZeroAlloc.Rest.AotSmoke/IUserApi.cs
+++ b/samples/ZeroAlloc.Rest.AotSmoke/IUserApi.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using ZeroAlloc.Rest.Attributes;
@@ -8,13 +7,6 @@ namespace ZeroAlloc.Rest.AotSmoke;
 [ZeroAllocRestClient]
 public interface IUserApi
 {
-    // The generator-emitted UserApiClient.GetUserAsync carries
-    // [Requires{Dynamic,Unreferenced}Code] — the interface must match or
-    // ILC raises IL3051/IL2046. Tracked as #42: the generator should emit
-    // [UnconditionalSuppressMessage] instead so consumers don't have to
-    // propagate the Requires annotations to every caller.
     [Get("/users/{id}")]
-    [RequiresDynamicCode("Generated client may deserialise via reflection.")]
-    [RequiresUnreferencedCode("Generated client may deserialise via reflection.")]
     Task<string?> GetUserAsync(int id, CancellationToken ct = default);
 }

--- a/src/ZeroAlloc.Rest.Generator/ClientEmitter.cs
+++ b/src/ZeroAlloc.Rest.Generator/ClientEmitter.cs
@@ -127,8 +127,14 @@ internal static class ClientEmitter
             ? fieldName
             : "_serializer";
 
-        sb.AppendLine("    [System.Diagnostics.CodeAnalysis.RequiresDynamicCode(\"Serialization of arbitrary types may require dynamic code.\")]");
-        sb.AppendLine("    [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(\"Serialization of arbitrary types may require unreferenced code.\")]");
+        // IL3051/IL2046: Previously we emitted [RequiresDynamicCode] / [RequiresUnreferencedCode]
+        // here, but the user-authored interface doesn't carry those annotations — ILC rejects
+        // the mismatch and forces consumers to propagate the Requires attributes to every
+        // caller. Switch to [UnconditionalSuppressMessage] which flows no obligation to the
+        // caller: the serializer is provided by the consumer, so its trim/AOT-unsafety is
+        // their concern, not the client wrapper's.
+        sb.AppendLine("    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage(\"Trimming\", \"IL2026\", Justification = \"IRestSerializer is provided by the consumer; its trim-unsafety is their concern. The generated client only forwards the call.\")]");
+        sb.AppendLine("    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage(\"AOT\", \"IL3050\", Justification = \"IRestSerializer is provided by the consumer; its AOT-unsafety is their concern. The generated client only forwards the call.\")]");
         sb.AppendLine($"    public async {method.ReturnTypeName} {method.Name}({BuildParamList(method.Parameters)})");
         sb.AppendLine("    {");
 


### PR DESCRIPTION
Closes #42.

Generator-emitted client methods no longer carry `[RequiresDynamicCode]` / `[RequiresUnreferencedCode]`. Switched to `[UnconditionalSuppressMessage]` so consumers don't have to propagate the annotations through every caller.

Also removes the workaround from the AOT smoke sample's `IUserApi`.