### PR TITLE
docs(rest): cross-link to [TypedId] cookbook from parameters guide

### DIFF
--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -17,6 +17,8 @@ Named in the route template with `{name}`. The method parameter with the same na
 Task<UserDto> GetUserAsync(int id, CancellationToken ct = default);
 ```
 
+Strongly-typed identifiers from [`ZeroAlloc.ValueObjects`](https://www.nuget.org/packages/ZeroAlloc.ValueObjects) `[TypedId]` are also supported as path or query parameters — the generator calls `id.ToString()` on the typed wrapper, which produces the strategy-specific string format (ULID base32 by default). See the [`Strongly-typed IDs` cookbook entry](cookbook/05-typed-ids.md) for a worked example.
+
 ## Query parameters
 
 Decorated with `[Query]`. They are appended to the URL as `?name=value`:


### PR DESCRIPTION
## Summary
One-paragraph addition to `docs/parameters.md` mentioning `[TypedId]` support and linking to the cookbook entry shipped in PR #56. Aids discoverability for users who land on the parameters reference first.

## Why
The cookbook entry is reachable via Docusaurus sidebar, but the parameters reference page is the first place a user looks when researching how Rest handles non-primitive route/query types. A two-line cross-reference closes the discoverability gap without duplicating content.

## Scope
- Single edit to `docs/parameters.md` Path parameters section
- No code changes
- No test changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)