### PR TITLE
chore(release): promote ZeroAlloc.Rest to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.0
+
+Stability milestone — public API of `ZeroAlloc.Rest` is now considered stable. Bundles in PR #58 (added `rest.requests_total` counter + `rest.request_duration_ms` histogram + `rest.method` tag for OpenTelemetry instrumentation). This release marks the transition out of pre-1.0 SemVer.
+
 ## [0.1.4](https://github.com/ZeroAlloc-Net/ZeroAlloc.Rest/compare/v0.1.3...v0.1.4) (2026-04-25)
 
 


### PR DESCRIPTION
## Summary
Promote the package to the 1.0 stability milestone. Bundles the recent telemetry-metrics work (PR #58) into a 1.0.0 release rather than 0.2.0.

Part of an ecosystem-wide campaign promoting all sub-1.0 ZeroAlloc packages to 1.0.0 now that the integration matrix is complete.

## Mechanism
The merge commit footer `Release-As: 1.0.0` instructs release-please to release as 1.0.0 (overriding its default 0.1.4 → 0.2.0 minor bump).

Release-As: 1.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)