### PR TITLE
fix: pack generator DLL under analyzers/dotnet/cs (#67)

### DIFF
--- a/src/ZeroAlloc.Rest.Generator/ZeroAlloc.Rest.Generator.csproj
+++ b/src/ZeroAlloc.Rest.Generator/ZeroAlloc.Rest.Generator.csproj
@@ -3,6 +3,15 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <IsRoslynComponent>true</IsRoslynComponent>
+
+    <!--
+      Source-generator packaging: ship the generator DLL under analyzers/dotnet/cs so
+      Roslyn loads it as an analyzer. Without IncludeBuildOutput=false the build output
+      ends up under lib/ and consumers silently get no source generator (issue #67).
+    -->
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <DevelopmentDependency>true</DevelopmentDependency>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
@@ -11,5 +20,20 @@
   <ItemGroup>
     <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
     <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
+  </ItemGroup>
+  <!--
+    Pack the generator DLL under analyzers/dotnet/cs. Without this, dotnet pack falls back
+    to the default lib/<tfm>/ layout and Roslyn does not load the generator at all.
+  -->
+  <ItemGroup>
+    <None Include="$(OutputPath)\$(AssemblyName).dll"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs"
+          Visible="false" />
+    <None Include="$(OutputPath)\$(AssemblyName).pdb"
+          Pack="true"
+          PackagePath="analyzers/dotnet/cs"
+          Visible="false"
+          Condition="Exists('$(OutputPath)\$(AssemblyName).pdb')" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
Closes #67.

ZeroAlloc.Rest.Generator was packing the generator DLL under `lib/netstandard2.0/` instead of `analyzers/dotnet/cs/`. Roslyn only loads source generators from the analyzers path, so consumers of `ZeroAlloc.Rest.Generator 1.0.2` got an empty `obj/Debug/<tfm>/generated/` and silently received no generated REST client code, even with `OutputItemType="Analyzer"` and `ReferenceOutputAssembly="false"` in the PackageReference.

## Fix
Three property additions + one ItemGroup, matching the canonical pattern used by `ZeroAlloc.Mediator.Generator` and `ZeroAlloc.EventSourcing.Generators`:

- `IncludeBuildOutput=false` — suppresses the default `lib/<tfm>/` output
- `DevelopmentDependency=true` — marks the package as build-only, not transitive
- `SuppressDependenciesWhenPacking=true` — keeps Roslyn deps out of the consumer's graph
- `<None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" />` — places the DLL where Roslyn looks

## Test plan
- [ ] CI green
- [ ] Run `dotnet pack` locally and inspect the produced `.nupkg` — confirm the generator DLL is at `analyzers/dotnet/cs/ZeroAlloc.Rest.Generator.dll` and **not** at `lib/netstandard2.0/`
- [ ] Wire the published package into a fresh .NET 10 project and verify the `[ZeroAllocRestClient]` interface produces generated code in `obj/Debug/net10.0/generated/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)