### PR TITLE
feat: bundle source generator into ZeroAlloc.Rest package

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@
 
 ## Install
 
+The source generator is bundled into the main package — a single `PackageReference` is all you need:
+
 ```sh
 dotnet add package ZeroAlloc.Rest
-dotnet add package ZeroAlloc.Rest.Generator
 dotnet add package ZeroAlloc.Rest.SystemTextJson
 ```
 
@@ -20,12 +21,10 @@ Or via `<PackageReference>`:
 
 ```xml
 <PackageReference Include="ZeroAlloc.Rest" Version="x.y.z" />
-<PackageReference Include="ZeroAlloc.Rest.Generator"
-                  Version="x.y.z"
-                  OutputItemType="Analyzer"
-                  ReferenceOutputAssembly="false" />
 <PackageReference Include="ZeroAlloc.Rest.SystemTextJson" Version="x.y.z" />
 ```
+
+> The standalone `ZeroAlloc.Rest.Generator` package is still published for backwards compatibility with existing direct PackageReferences, but new consumers should reference only `ZeroAlloc.Rest`.
 
 ### Optional: resilience policies
 
@@ -34,7 +33,6 @@ To add retry, timeout, and circuit-breaker behaviour to a client, install the br
 ```sh
 dotnet add package ZeroAlloc.Rest.Resilience
 dotnet add package ZeroAlloc.Resilience
-dotnet add package ZeroAlloc.Resilience.Generator  # analyzer reference
 ```
 
 ## Quick Start

--- a/src/ZeroAlloc.Rest/ZeroAlloc.Rest.csproj
+++ b/src/ZeroAlloc.Rest/ZeroAlloc.Rest.csproj
@@ -16,4 +16,25 @@
   <ItemGroup>
     <PackageReference Include="ZeroAlloc.ValueObjects" />
   </ItemGroup>
+
+  <!--
+    Bundle the source generator into the NuGet package so consumers get it by
+    referencing only ZeroAlloc.Rest. The standalone ZeroAlloc.Rest.Generator
+    package is still published for backwards compatibility, but new consumers
+    should reference the main package only.
+  -->
+  <ItemGroup>
+    <ProjectReference Include="..\ZeroAlloc.Rest.Generator\ZeroAlloc.Rest.Generator.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false"
+                      PrivateAssets="all" />
+  </ItemGroup>
+  <Target Name="IncludeGeneratorInPackage" BeforeTargets="_GetPackageFiles">
+    <ItemGroup>
+      <None Include="$(MSBuildThisFileDirectory)..\ZeroAlloc.Rest.Generator\bin\$(Configuration)\netstandard2.0\ZeroAlloc.Rest.Generator.dll"
+            Pack="true"
+            PackagePath="analyzers/dotnet/cs"
+            Visible="false" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
## Summary
Until now consumers had to install both `ZeroAlloc.Rest` and `ZeroAlloc.Rest.Generator` (with the right `OutputItemType` / `PrivateAssets` flags) to get a working setup. Bundling the generator DLL inside the main library's NuGet package under `analyzers/dotnet/cs/` means **a single `PackageReference` is now enough**.

`ZeroAlloc.Rest.Generator` continues to publish as a standalone package for backwards compatibility with existing direct `PackageReference`s. New consumers should reference only `ZeroAlloc.Rest`.

## What changes
- Add `<ProjectReference ... OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />` to the Generator project (dev-time wiring)
- Add `IncludeGeneratorInPackage` MSBuild target that packs the generator DLL under `analyzers/dotnet/cs/` in the main library's nupkg

## Test plan
- [ ] CI green
- [ ] `dotnet pack` produces `ZeroAlloc.Rest.nupkg` containing the generator DLL at `analyzers/dotnet/cs/`
- [ ] In a fresh project with only `<PackageReference Include="ZeroAlloc.Rest">`, a `[ZeroAllocRestClient]`-attributed interface produces generated code
- [ ] Existing setups with both `ZeroAlloc.Rest` and `ZeroAlloc.Rest.Generator` referenced continue to work (Roslyn dedupes same-version analyzers)

Related: #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)