### PR TITLE
feat: lock public API surface (PublicApiAnalyzers + api-compat gate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,12 @@ jobs:
             --source https://api.nuget.org/v3/index.json \
             --skip-duplicate
 
+  api-compat:
+    uses: ZeroAlloc-Net/.github/.github/workflows/api-compat.yml@main
+    with:
+      package-id: ZeroAlloc.Rest
+      csproj-path: src/ZeroAlloc.Rest/ZeroAlloc.Rest.csproj
+
   aot-smoke:
     runs-on: ubuntu-latest
     # Publishes samples/ZeroAlloc.Rest.AotSmoke with PublishAot=true. Verifies the

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,6 +6,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!--
+      Public API surface lock: RS0016 (missing entry) / RS0017 (extra entry) are
+      errors even if TreatWarningsAsErrors is locally disabled, so the public API
+      tracking files can never silently drift out of sync with the codebase.
+    -->
+    <WarningsAsErrors>$(WarningsAsErrors);RS0016;RS0017</WarningsAsErrors>
     <!-- Only audit direct dependencies; transitive vulnerability warnings (NU1902/NU1903) are owned by upstream packages -->
     <NuGetAuditMode>direct</NuGetAuditMode>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,6 +28,7 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="Refit" Version="10.1.6" />
     <!-- Analyzers -->
+    <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="4.14.0" />
     <PackageVersion Include="Meziantou.Analyzer" Version="3.0.58" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
     <PackageVersion Include="ErrorProne.NET.CoreAnalyzers" Version="0.1.2" />

--- a/src/ZeroAlloc.Rest/PublicAPI.Shipped.txt
+++ b/src/ZeroAlloc.Rest/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ZeroAlloc.Rest/PublicAPI.Unshipped.txt
+++ b/src/ZeroAlloc.Rest/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/ZeroAlloc.Rest/PublicAPI.Unshipped.txt
+++ b/src/ZeroAlloc.Rest/PublicAPI.Unshipped.txt
@@ -1,1 +1,70 @@
 #nullable enable
+const ZeroAlloc.Rest.ServiceCollectionExtensions.DefaultClientName = "ZeroAllocClient" -> string!
+override ZeroAlloc.Rest.HttpError.Equals(object? obj) -> bool
+override ZeroAlloc.Rest.HttpError.GetHashCode() -> int
+override ZeroAlloc.Rest.HttpError.ToString() -> string!
+static ZeroAlloc.Rest.HttpError.operator !=(ZeroAlloc.Rest.HttpError? left, ZeroAlloc.Rest.HttpError? right) -> bool
+static ZeroAlloc.Rest.HttpError.operator ==(ZeroAlloc.Rest.HttpError? left, ZeroAlloc.Rest.HttpError? right) -> bool
+static ZeroAlloc.Rest.ServiceCollectionExtensions.AddZeroAllocClient(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<ZeroAlloc.Rest.ZeroAllocClientOptions!>! configure) -> ZeroAlloc.Rest.ZeroAllocClientBuilder!
+ZeroAlloc.Rest.Attributes.BodyAttribute
+ZeroAlloc.Rest.Attributes.BodyAttribute.BodyAttribute() -> void
+ZeroAlloc.Rest.Attributes.DeleteAttribute
+ZeroAlloc.Rest.Attributes.DeleteAttribute.DeleteAttribute(string! route) -> void
+ZeroAlloc.Rest.Attributes.FormBodyAttribute
+ZeroAlloc.Rest.Attributes.FormBodyAttribute.FormBodyAttribute() -> void
+ZeroAlloc.Rest.Attributes.GetAttribute
+ZeroAlloc.Rest.Attributes.GetAttribute.GetAttribute(string! route) -> void
+ZeroAlloc.Rest.Attributes.HeaderAttribute
+ZeroAlloc.Rest.Attributes.HeaderAttribute.HeaderAttribute(string! name) -> void
+ZeroAlloc.Rest.Attributes.HeaderAttribute.Name.get -> string!
+ZeroAlloc.Rest.Attributes.HeaderAttribute.Value.get -> string?
+ZeroAlloc.Rest.Attributes.HeaderAttribute.Value.init -> void
+ZeroAlloc.Rest.Attributes.HttpMethodAttribute
+ZeroAlloc.Rest.Attributes.HttpMethodAttribute.HttpMethodAttribute(string! method, string! route) -> void
+ZeroAlloc.Rest.Attributes.HttpMethodAttribute.Method.get -> string!
+ZeroAlloc.Rest.Attributes.HttpMethodAttribute.Route.get -> string!
+ZeroAlloc.Rest.Attributes.PatchAttribute
+ZeroAlloc.Rest.Attributes.PatchAttribute.PatchAttribute(string! route) -> void
+ZeroAlloc.Rest.Attributes.PostAttribute
+ZeroAlloc.Rest.Attributes.PostAttribute.PostAttribute(string! route) -> void
+ZeroAlloc.Rest.Attributes.PutAttribute
+ZeroAlloc.Rest.Attributes.PutAttribute.PutAttribute(string! route) -> void
+ZeroAlloc.Rest.Attributes.QueryAttribute
+ZeroAlloc.Rest.Attributes.QueryAttribute.Name.get -> string?
+ZeroAlloc.Rest.Attributes.QueryAttribute.Name.init -> void
+ZeroAlloc.Rest.Attributes.QueryAttribute.QueryAttribute() -> void
+ZeroAlloc.Rest.Attributes.SerializerAttribute
+ZeroAlloc.Rest.Attributes.SerializerAttribute.SerializerAttribute(System.Type! serializerType) -> void
+ZeroAlloc.Rest.Attributes.SerializerAttribute.SerializerType.get -> System.Type!
+ZeroAlloc.Rest.Attributes.ZeroAllocRestClientAttribute
+ZeroAlloc.Rest.Attributes.ZeroAllocRestClientAttribute.ZeroAllocRestClientAttribute() -> void
+ZeroAlloc.Rest.HttpError
+ZeroAlloc.Rest.HttpError.<Clone>$() -> ZeroAlloc.Rest.HttpError!
+ZeroAlloc.Rest.HttpError.Deconstruct(out System.Net.HttpStatusCode StatusCode, out System.Collections.Generic.IReadOnlyDictionary<string!, System.Collections.Generic.IReadOnlyList<string!>!>! Headers, out string? Message) -> void
+ZeroAlloc.Rest.HttpError.Equals(ZeroAlloc.Rest.HttpError? other) -> bool
+ZeroAlloc.Rest.HttpError.Headers.get -> System.Collections.Generic.IReadOnlyDictionary<string!, System.Collections.Generic.IReadOnlyList<string!>!>!
+ZeroAlloc.Rest.HttpError.Headers.init -> void
+ZeroAlloc.Rest.HttpError.HttpError(System.Net.HttpStatusCode StatusCode, System.Collections.Generic.IReadOnlyDictionary<string!, System.Collections.Generic.IReadOnlyList<string!>!>! Headers, string? Message = null) -> void
+ZeroAlloc.Rest.HttpError.Message.get -> string?
+ZeroAlloc.Rest.HttpError.Message.init -> void
+ZeroAlloc.Rest.HttpError.StatusCode.get -> System.Net.HttpStatusCode
+ZeroAlloc.Rest.HttpError.StatusCode.init -> void
+ZeroAlloc.Rest.IRestSerializer
+ZeroAlloc.Rest.IRestSerializer.ContentType.get -> string!
+ZeroAlloc.Rest.IRestSerializer.DeserializeAsync<T>(System.IO.Stream! stream, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<T?>
+ZeroAlloc.Rest.IRestSerializer.SerializeAsync<T>(System.IO.Stream! stream, T value, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+ZeroAlloc.Rest.RestSerializerAdapter<T>
+ZeroAlloc.Rest.RestSerializerAdapter<T>.ContentType.get -> string!
+ZeroAlloc.Rest.RestSerializerAdapter<T>.DeserializeAsync<TResult>(System.IO.Stream! stream, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<TResult?>
+ZeroAlloc.Rest.RestSerializerAdapter<T>.RestSerializerAdapter(ZeroAlloc.Serialisation.ISerializer<T>! serializer, string! contentType) -> void
+ZeroAlloc.Rest.RestSerializerAdapter<T>.SerializeAsync<TValue>(System.IO.Stream! stream, TValue value, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask
+ZeroAlloc.Rest.ServiceCollectionExtensions
+ZeroAlloc.Rest.ZeroAllocClientBuilder
+ZeroAlloc.Rest.ZeroAllocClientBuilder.ConfigureHttpClient(System.Action<System.Net.Http.HttpClient!>! configure) -> ZeroAlloc.Rest.ZeroAllocClientBuilder!
+ZeroAlloc.Rest.ZeroAllocClientBuilder.ZeroAllocClientBuilder(Microsoft.Extensions.DependencyInjection.IHttpClientBuilder! httpClientBuilder) -> void
+ZeroAlloc.Rest.ZeroAllocClientOptions
+ZeroAlloc.Rest.ZeroAllocClientOptions.BaseAddress.get -> System.Uri?
+ZeroAlloc.Rest.ZeroAllocClientOptions.BaseAddress.set -> void
+ZeroAlloc.Rest.ZeroAllocClientOptions.SerializerType.get -> System.Type?
+ZeroAlloc.Rest.ZeroAllocClientOptions.UseSerializer<TSerializer>() -> void
+ZeroAlloc.Rest.ZeroAllocClientOptions.ZeroAllocClientOptions() -> void

--- a/src/ZeroAlloc.Rest/ZeroAlloc.Rest.csproj
+++ b/src/ZeroAlloc.Rest/ZeroAlloc.Rest.csproj
@@ -9,6 +9,12 @@
     <PackageReference Include="ZeroAlloc.Results" />
     <PackageReference Include="ZeroAlloc.Collections" />
     <PackageReference Include="ZeroAlloc.Analyzers" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ZeroAlloc.Serialisation" />


### PR DESCRIPTION
## Summary

Phase B fan-out of the public-API gating pattern, applied to the runtime contract `ZeroAlloc.Rest`.

- Adds `Microsoft.CodeAnalysis.PublicApiAnalyzers 4.14.0` with `PublicAPI.Shipped.txt` / `PublicAPI.Unshipped.txt` tracking files on `src/ZeroAlloc.Rest/ZeroAlloc.Rest.csproj`
- Baseline populated with the existing 69 public symbols (no surface change)
- `RS0016` / `RS0017` promoted to errors via `WarningsAsErrors` in `Directory.Build.props` so the tracking files cannot drift even if a project locally disables `TreatWarningsAsErrors`
- Adds reusable `api-compat` CI job for binary/source compat against the previous published `ZeroAlloc.Rest` package

The generator + sub-packages (`Rest.SystemTextJson`, `Rest.MessagePack`, `Rest.MemoryPack`, `Rest.Resilience`, `Rest.Tools`, `Rest.Generator`) are intentionally out of scope for this phase.

## Public surface size

69 entries.

## Sibling PRs

Part of the Phase B fan-out applying the same pattern across the ZeroAlloc ecosystem:

- ZeroAlloc-Net/ZeroAlloc.Authorization#5
- ZeroAlloc-Net/ZeroAlloc.AsyncEvents#47
- ZeroAlloc-Net/ZeroAlloc.Notify#43
- ZeroAlloc-Net/ZeroAlloc.Telemetry#19
- ZeroAlloc-Net/ZeroAlloc.ValueObjects#38
- ZeroAlloc-Net/ZeroAlloc.Outbox#44
- ZeroAlloc-Net/ZeroAlloc.Scheduling#44
- ZeroAlloc-Net/ZeroAlloc.Resilience#26
- ZeroAlloc-Net/ZeroAlloc.StateMachine#13
- ZeroAlloc-Net/ZeroAlloc.Inject#51

## Test plan

- [x] `dotnet build ZeroAlloc.Rest.slnx -c Release` clean (0 errors)
- [x] `dotnet test ZeroAlloc.Rest.slnx -c Release` all green (90/90 passing)
- [x] Baseline regenerated → 0 RS0016/RS0017 warnings under the new error gating
- [ ] CI `api-compat` job passes on this PR