### PR TITLE
fix(release-please): drop pre-major flags (package is post-1.0)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,9 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "packages": {
     ".": {
-      "release-type": "simple",
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "release-type": "simple"
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
## Summary
- Removes `bump-minor-pre-major` and `bump-patch-for-minor-pre-major` from `release-please-config.json`.
- These flags are documented as pre-1.0 only: they demote `BREAKING CHANGE` from major to minor, and `feat!` from minor to patch.
- ZeroAlloc.Rest is at **1.1.1** (post-1.0). With these flags active, the next `feat!` commit would silently mis-version, violating SemVer.
- Same defect class as the recent ZeroAlloc.Mediator fix (PR #65 there).

## Test plan
- [ ] CI passes on this branch
- [ ] Confirm release-please bot opens/updates its release PR with correct SemVer bumps after merge
- [ ] Next `feat!` commit produces a major bump (2.0.0), not a minor

🤖 Generated with [Claude Code](https://claude.com/claude-code)