### PR TITLE
ci: remove auto-publish to nuget on every main push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,14 +50,6 @@ jobs:
       - name: Pack
         run: dotnet pack ZeroAlloc.Rest.slnx --no-build -c Release -p:Version=${{ steps.gitversion.outputs.semver }} -o ./nupkg
 
-      - name: Push to NuGet (pre-release alpha)
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        run: |
-          dotnet nuget push ./nupkg/*.nupkg \
-            --api-key ${{ secrets.NUGET_API_KEY }} \
-            --source https://api.nuget.org/v3/index.json \
-            --skip-duplicate
-
   api-compat:
     uses: ZeroAlloc-Net/.github/.github/workflows/api-compat.yml@main
     with:


### PR DESCRIPTION
## Summary
- Removes the `Push to NuGet (pre-release alpha)` step from `.github/workflows/ci.yml`.
- Per org-wide decision: only release-please-shepherded releases should publish to NuGet.
- The removed step ran on every main push, shipping continuous-prerelease versions that competed with release-please's bookkeeping.
- Build / test / pack / api-compat / aot-smoke jobs are untouched.

## Test plan
- [ ] CI runs green on this PR (build/test/pack still pass)
- [ ] Verify no `dotnet nuget push` step remains in `ci.yml`
- [ ] Confirm release-please workflow still owns publishing