### PR TITLE
feat(build): emit ZR9001 when consumers reference both ZeroAlloc.Rest and ZeroAlloc.Rest.Generator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,11 @@ jobs:
       - name: Build
         run: dotnet build ZeroAlloc.Rest.slnx --no-restore -c Release -p:Version=${{ steps.gitversion.outputs.semver }}
 
+      - name: Pack ZA.Rest packages into local feed (for duplicate-generator test)
+        run: |
+          dotnet pack src/ZeroAlloc.Rest/ZeroAlloc.Rest.csproj -c Release -o artifacts/local
+          dotnet pack src/ZeroAlloc.Rest.Generator/ZeroAlloc.Rest.Generator.csproj -c Release -o artifacts/local
+
       - name: Test
         run: dotnet test ZeroAlloc.Rest.slnx --no-build -c Release --logger "trx" --results-directory ./test-results
 

--- a/ZeroAlloc.Rest.slnx
+++ b/ZeroAlloc.Rest.slnx
@@ -13,6 +13,7 @@
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/ZeroAlloc.Rest.Tests/ZeroAlloc.Rest.Tests.csproj" />
+    <Project Path="tests/ZeroAlloc.Rest.DuplicateGeneratorTests/ZeroAlloc.Rest.DuplicateGeneratorTests.csproj" />
     <Project Path="tests/ZeroAlloc.Rest.Generator.Tests/ZeroAlloc.Rest.Generator.Tests.csproj" />
     <Project Path="tests/ZeroAlloc.Rest.Integration.Tests/ZeroAlloc.Rest.Integration.Tests.csproj" />
     <Project Path="tests/ZeroAlloc.Rest.Tools.Tests/ZeroAlloc.Rest.Tools.Tests.csproj" />

--- a/src/ZeroAlloc.Rest/ZeroAlloc.Rest.csproj
+++ b/src/ZeroAlloc.Rest/ZeroAlloc.Rest.csproj
@@ -43,4 +43,10 @@
             Visible="false" />
     </ItemGroup>
   </Target>
+  <ItemGroup>
+    <None Include="build/ZeroAlloc.Rest.targets"
+          Pack="true"
+          PackagePath="build/"
+          Visible="false" />
+  </ItemGroup>
 </Project>

--- a/src/ZeroAlloc.Rest/build/ZeroAlloc.Rest.targets
+++ b/src/ZeroAlloc.Rest/build/ZeroAlloc.Rest.targets
@@ -10,7 +10,7 @@
   <Target Name="ZeroAllocRestGeneratorDuplicateCheck" BeforeTargets="CoreCompile">
     <ItemGroup>
       <_RedundantZeroAllocRestGeneratorRef Include="@(PackageReference)"
-                                            Condition="'%(Identity)' == 'ZeroAlloc.Rest.Generator'" />
+                                            Condition="'$([MSBuild]::ValueOrDefault('%(Identity)', '').ToLowerInvariant())' == 'zeroalloc.rest.generator'" />
     </ItemGroup>
     <Error Condition="'@(_RedundantZeroAllocRestGeneratorRef)' != ''"
            Code="ZR9001"

--- a/src/ZeroAlloc.Rest/build/ZeroAlloc.Rest.targets
+++ b/src/ZeroAlloc.Rest/build/ZeroAlloc.Rest.targets
@@ -9,8 +9,15 @@
   -->
   <Target Name="ZeroAllocRestGeneratorDuplicateCheck" BeforeTargets="CoreCompile">
     <ItemGroup>
+      <!--
+        Identity match: canonical case (what nuget.org and `dotnet add package` produce)
+        plus all-lowercase (the realistic hand-typed typo). MSBuild does not allow
+        item metadata `%(Identity)` inside property functions, so we cannot lowercase
+        via `[System.String]::ToLowerInvariant()` — the Or chain is the canonical
+        workaround for case-insensitive item-metadata matching in conditions.
+      -->
       <_RedundantZeroAllocRestGeneratorRef Include="@(PackageReference)"
-                                            Condition="'$([MSBuild]::ValueOrDefault('%(Identity)', '').ToLowerInvariant())' == 'zeroalloc.rest.generator'" />
+                                            Condition="'%(Identity)' == 'ZeroAlloc.Rest.Generator' Or '%(Identity)' == 'zeroalloc.rest.generator'" />
     </ItemGroup>
     <Error Condition="'@(_RedundantZeroAllocRestGeneratorRef)' != ''"
            Code="ZR9001"

--- a/src/ZeroAlloc.Rest/build/ZeroAlloc.Rest.targets
+++ b/src/ZeroAlloc.Rest/build/ZeroAlloc.Rest.targets
@@ -1,0 +1,19 @@
+<Project>
+  <!--
+    Auto-imported by NuGet from build/<PackageId>.targets when a project
+    references the ZeroAlloc.Rest package.
+
+    Emits ZR9001 when the consumer also references ZeroAlloc.Rest.Generator
+    directly. ZeroAlloc.Rest bundles the generator already; the dual reference
+    causes the generator to load twice and produces duplicate-type errors.
+  -->
+  <Target Name="ZeroAllocRestGeneratorDuplicateCheck" BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <_RedundantZeroAllocRestGeneratorRef Include="@(PackageReference)"
+                                            Condition="'%(Identity)' == 'ZeroAlloc.Rest.Generator'" />
+    </ItemGroup>
+    <Error Condition="'@(_RedundantZeroAllocRestGeneratorRef)' != ''"
+           Code="ZR9001"
+           Text="ZeroAlloc.Rest bundles the source generator. Remove the redundant 'ZeroAlloc.Rest.Generator' PackageReference — reference only 'ZeroAlloc.Rest'. See https://github.com/ZeroAlloc-Net/ZeroAlloc.Rest#install" />
+  </Target>
+</Project>

--- a/tests/ZeroAlloc.Rest.DuplicateGeneratorTests/DuplicateGeneratorDiagnosticTests.cs
+++ b/tests/ZeroAlloc.Rest.DuplicateGeneratorTests/DuplicateGeneratorDiagnosticTests.cs
@@ -14,7 +14,13 @@ public sealed class DuplicateGeneratorDiagnosticTests
         Assert.True(Directory.Exists(feed),
             $"Local nupkg feed not found at {feed}. Run `dotnet pack -c Release -o artifacts/local` first.");
 
-        var restNupkg = Directory.GetFiles(feed, "ZeroAlloc.Rest.*.nupkg");
+        // The "ZeroAlloc.Rest.*.nupkg" glob also matches "ZeroAlloc.Rest.Generator.*.nupkg"
+        // because `*` greedily eats "Generator.<version>". Filter it out explicitly — relying
+        // on enumeration order is unreliable across file systems (worked on Windows NTFS,
+        // returned Generator first on Linux ext4 in CI).
+        var restNupkg = Directory.GetFiles(feed, "ZeroAlloc.Rest.*.nupkg")
+            .Where(f => !Path.GetFileName(f).StartsWith("ZeroAlloc.Rest.Generator.", StringComparison.Ordinal))
+            .ToArray();
         var genNupkg = Directory.GetFiles(feed, "ZeroAlloc.Rest.Generator.*.nupkg");
         Assert.NotEmpty(restNupkg);
         Assert.NotEmpty(genNupkg);

--- a/tests/ZeroAlloc.Rest.DuplicateGeneratorTests/DuplicateGeneratorDiagnosticTests.cs
+++ b/tests/ZeroAlloc.Rest.DuplicateGeneratorTests/DuplicateGeneratorDiagnosticTests.cs
@@ -1,0 +1,100 @@
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace ZeroAlloc.Rest.DuplicateGeneratorTests;
+
+public sealed class DuplicateGeneratorDiagnosticTests
+{
+    [Fact]
+    public async Task Build_Fails_With_ZR9001_When_Both_Packages_Referenced()
+    {
+        var repoRoot = LocateRepoRoot();
+        var feed = Path.Combine(repoRoot, "artifacts", "local");
+        Assert.True(Directory.Exists(feed),
+            $"Local nupkg feed not found at {feed}. Run `dotnet pack -c Release -o artifacts/local` first.");
+
+        var restNupkg = Directory.GetFiles(feed, "ZeroAlloc.Rest.*.nupkg");
+        var genNupkg = Directory.GetFiles(feed, "ZeroAlloc.Rest.Generator.*.nupkg");
+        Assert.NotEmpty(restNupkg);
+        Assert.NotEmpty(genNupkg);
+
+        var version = Path.GetFileNameWithoutExtension(restNupkg[0])
+            .Substring("ZeroAlloc.Rest.".Length);
+
+        var workDir = Path.Combine(Path.GetTempPath(), "za-rest-dup-gen-" + Path.GetRandomFileName());
+        Directory.CreateDirectory(workDir);
+        try
+        {
+            ScaffoldConsumer(workDir, feed, version);
+            var (exitCode, stdout, stderr) = await RunDotnetAsync(workDir, "build", "-c", "Release");
+            Assert.NotEqual(0, exitCode);
+            var combined = stdout + "\n" + stderr;
+            Assert.Contains("ZR9001", combined, StringComparison.Ordinal);
+        }
+        finally
+        {
+            try { Directory.Delete(workDir, recursive: true); }
+            catch (IOException) { /* best effort */ }
+            catch (UnauthorizedAccessException) { /* best effort */ }
+        }
+    }
+
+    private static void ScaffoldConsumer(string workDir, string feed, string version)
+    {
+        File.WriteAllText(Path.Combine(workDir, "NuGet.config"),
+            $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <packageSources>
+                <clear />
+                <add key="local" value="{feed}" />
+                <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+              </packageSources>
+            </configuration>
+            """);
+
+        File.WriteAllText(Path.Combine(workDir, "Consumer.csproj"),
+            $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="ZeroAlloc.Rest" Version="{version}" />
+                <PackageReference Include="ZeroAlloc.Rest.Generator" Version="{version}" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        File.WriteAllText(Path.Combine(workDir, "Program.cs"), "// empty consumer\n");
+    }
+
+    private static async Task<(int ExitCode, string StdOut, string StdErr)> RunDotnetAsync(
+        string workingDirectory, params string[] args)
+    {
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = workingDirectory,
+        };
+        foreach (var a in args) psi.ArgumentList.Add(a);
+
+        using var p = Process.Start(psi)!;
+        var stdoutTask = p.StandardOutput.ReadToEndAsync();
+        var stderrTask = p.StandardError.ReadToEndAsync();
+        await p.WaitForExitAsync().ConfigureAwait(false);
+        return (p.ExitCode, await stdoutTask.ConfigureAwait(false), await stderrTask.ConfigureAwait(false));
+    }
+
+    private static string LocateRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Directory.Build.props")))
+            dir = dir.Parent;
+        return dir?.FullName ?? throw new DirectoryNotFoundException("Could not find repo root (Directory.Build.props)");
+    }
+}

--- a/tests/ZeroAlloc.Rest.DuplicateGeneratorTests/ZeroAlloc.Rest.DuplicateGeneratorTests.csproj
+++ b/tests/ZeroAlloc.Rest.DuplicateGeneratorTests/ZeroAlloc.Rest.DuplicateGeneratorTests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <!-- Build-orchestration test: spawns dotnet build for a temp consumer project -->
-    <NoWarn>$(NoWarn);MA0048</NoWarn>
+    <!-- MA0004: ConfigureAwait conflicts with xUnit1030 inside [Fact] bodies — xUnit's rule takes precedence in test projects -->
+    <NoWarn>$(NoWarn);MA0004;MA0048</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit" />

--- a/tests/ZeroAlloc.Rest.DuplicateGeneratorTests/ZeroAlloc.Rest.DuplicateGeneratorTests.csproj
+++ b/tests/ZeroAlloc.Rest.DuplicateGeneratorTests/ZeroAlloc.Rest.DuplicateGeneratorTests.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Build-orchestration test: spawns dotnet build for a temp consumer project -->
+    <NoWarn>$(NoWarn);MA0048</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- Ship `build/ZeroAlloc.Rest.targets` inside the ZA.Rest nupkg that emits MSBuild error ZR9001 when a consumer also references the standalone `ZeroAlloc.Rest.Generator` package
- Add integration test (`DuplicateGeneratorDiagnosticTests`) that packs both nupkgs into a local feed, scaffolds a deliberately misconfigured consumer, and asserts the build fails with ZR9001
- CI packs the nupkgs as a prerequisite for the new test

## Why
ZeroAlloc.Rest already bundles the source generator. The standalone `ZeroAlloc.Rest.Generator` package is still published for backwards compatibility. Consumers that accidentally reference both load the generator twice and get duplicate-type compile errors that are hard to diagnose from the surface symptom. ZR9001 makes the misconfiguration obvious.

## SemVer
Patch — the dual-reference scenario was already broken; this just improves the error message.

## Test plan
- [x] `dotnet build -c Release` green; in-repo build does NOT trip ZR9001 (uses ProjectReference, not PackageReference)
- [x] `dotnet test` green including new `DuplicateGeneratorDiagnosticTests`
- [x] Manually verified: `unzip -l ZeroAlloc.Rest.<version>.nupkg | grep build/` shows `build/ZeroAlloc.Rest.targets` shipped
- [x] Manual repro confirms ZR9001 fires with the full error text when a consumer references both packages

## Trade-offs documented in code
- Identity matching is canonical-case + all-lowercase via `Or` chain. MSBuild does not permit item metadata inside property functions, so full case-insensitive comparison via `[System.String]::ToLowerInvariant()` is not available. The two casings covered (`ZeroAlloc.Rest.Generator` and `zeroalloc.rest.generator`) cover what `nuget.org`, `dotnet add package`, and the realistic hand-typed lowercase typo produce. Mixed-case variants like `ZeroAlloc.REST.Generator` would slip past — deliberate trade-off.
