### PR TITLE
docs(backlog): mark v1 deferred items as shipped

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -4,60 +4,16 @@ Enhancements identified from real-world usage patterns. Items are independent an
 
 ---
 
-## 1. Static `[Header]` on methods
+## Shipped
 
-**Status:** Attribute + `Value` property already exist — generator support is missing.
+The original three v1 deferred items have all shipped — kept here for traceability:
 
-The `HeaderAttribute` has a `Value` property intended for compile-time static headers on methods:
-
-```csharp
-[Get("/files/{path}")]
-[Header("Accept", Value = "application/octet-stream")]
-Task<byte[]> GetFileAsync(string path, CancellationToken ct = default);
-```
-
-Today, `Value` is never extracted by `ModelExtractor` and never emitted by `ClientEmitter`. The workaround is setting the header via `ConfigureHttpClient`, which is global — not per-method.
-
-**Work needed:**
-- Extract static headers from method-level `[Header]` attributes in `ModelExtractor.ExtractMethod`
-- Add a `StaticHeaders` collection to `MethodModel`
-- Emit `request.Headers.TryAddWithoutValidation(name, value)` in `ClientEmitter.EmitRequestCreation`
+1. **Static `[Header]` on methods.** Extractor + emitter wired. `MethodModel.StaticHeaders` is populated from method-level `[Header(name, Value = ...)]` and emitted via `request.Headers.TryAddWithoutValidation(...)` in `ClientEmitter`.
+2. **Multi-value query parameters (`IEnumerable<T>` with `[Query]`).** `ParameterModel.IsCollection` flag drives a `foreach` emission in `ClientEmitter`, producing the `?tags=a&tags=b` shape required by APIs that accept repeated keys.
+3. **Form-encoded body (`[FormBody]`).** `FormBodyAttribute` + `ParameterKind.FormBody` end-to-end; `ClientEmitter` builds `FormUrlEncodedContent` from the parameter's public properties (AOT-safe, source-generated, no reflection). Useful for OAuth token endpoints and legacy form-urlencoded APIs.
 
 ---
 
-## 2. Multi-value query parameters (`IEnumerable<T>` with `[Query]`)
+## Open
 
-**Status:** Not supported — passing a collection for a `[Query]` parameter emits a single value via `.ToString()`.
-
-APIs that accept repeated keys (`?tags=a&tags=b`) require manual query string construction today:
-
-```csharp
-[Get("/items")]
-Task<List<ItemDto>> SearchAsync([Query] IEnumerable<string> tags, CancellationToken ct = default);
-// desired: ?tags=a&tags=b
-```
-
-**Work needed:**
-- Detect `IEnumerable<T>` (excluding `string`) on `[Query]` parameters in `ModelExtractor`
-- Add an `IsCollection` flag to `ParameterModel`
-- In `ClientEmitter`, emit a `foreach` loop over the collection, appending each value as a separate `key=value` pair
-- Handle nullable collections
-
----
-
-## 3. Form-encoded body (`[FormBody]`)
-
-**Status:** Not supported — the generator only serializes bodies via `IRestSerializer` (JSON, MessagePack, etc.).
-
-OAuth token endpoints and many legacy APIs require `application/x-www-form-urlencoded`. Today there is no way to declare this on the interface:
-
-```csharp
-[Post("/oauth/token")]
-Task<TokenResponse> GetTokenAsync([FormBody] TokenRequest request, CancellationToken ct = default);
-```
-
-**Work needed:**
-- Add `FormBodyAttribute` to `ZeroAlloc.Rest.Attributes`
-- Detect it in `ModelExtractor` (new `ParameterKind.FormBody`)
-- In `ClientEmitter`, emit `FormUrlEncodedContent` built from the parameter's public properties (source-generated via a helper, to stay AOT-safe — no reflection)
-- Consider a `Dictionary<string, string>` overload as a simpler escape hatch
+(none — add new deferred items below as they accumulate)


### PR DESCRIPTION
## Summary
All three v1 deferred items in the Rest backlog have shipped — rewriting the file to reflect reality, keeping the shipped items for traceability and leaving a clean "Open" section for future deferred items.

Audit verified shipped state in source:
- **Static `[Header]` on methods**: `MethodModel.StaticHeaders` + `ClientEmitter.cs:236` emission
- **Multi-value query params**: `ParameterModel.IsCollection` flag + foreach emission at `ClientEmitter.cs:187`
- **Form-encoded body**: `FormBodyAttribute` in `Attributes/ParameterAttributes.cs` + `ParameterKind.FormBody` end-to-end (`ModelExtractor.cs:149`, `ClientEmitter.cs:119`)

## Test plan
- [x] No code changes; doc-only PR
- [x] Audit cross-referenced against `PublicAPI.Unshipped.txt` (FormBodyAttribute listed there — separate housekeeping, not blocking this PR)