### PR TITLE
fix(deps): bump Refit 10.2.0 (revoked cert) + MessagePack 3.1.7 (CVE)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
     <!-- Serializers -->
-    <PackageVersion Include="MessagePack" Version="3.1.6" />
+    <PackageVersion Include="MessagePack" Version="3.1.7" />
     <!-- MessagePack 3.x bundles the source generator; no separate MessagePack.SourceGenerator package exists for 3.x -->
     <PackageVersion Include="MemoryPack" Version="1.21.4" />
     <!-- OpenAPI -->
@@ -26,7 +26,7 @@
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.6.3" />
     <!-- Benchmarks -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageVersion Include="Refit" Version="10.1.6" />
+    <PackageVersion Include="Refit" Version="10.2.0" />
     <!-- Analyzers -->
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="4.14.0" />
     <PackageVersion Include="Meziantou.Analyzer" Version="3.0.98" />


### PR DESCRIPTION
Refit 10.1.6 author signing certificate was revoked (NU3012). MessagePack 3.1.6 has known high-severity vulnerability [GHSA-hv8m-jj95-wg3x](https://github.com/advisories/GHSA-hv8m-jj95-wg3x) (NU1903). Both errors fail restore together, so bumping in one commit unblocks the in-flight Renovate PRs #120–#124.